### PR TITLE
Fix metadata searches for submission and allow alerts to have multilevel metadata

### DIFF
--- a/assemblyline/datastore/support/elasticsearch/build.py
+++ b/assemblyline/datastore/support/elasticsearch/build.py
@@ -109,16 +109,17 @@ def build_mapping(field_data, prefix=None, allow_refuse_implicit=True):
                 data['normalizer'] = __normalizer_mapping[field.__class__]
             mappings[name.strip(".")] = set_mapping(field, data)
 
-        elif isinstance(field, FlattenedObject):
-            mappings[name.strip(".")] = {
-                'type': __type_mapping[field.__class__]
-            }
-
         elif isinstance(field, Date):
             mappings[name.strip(".")] = set_mapping(field, {
                 'type': __type_mapping[field.__class__],
                 'format': 'date_optional_time||epoch_millis',
             })
+
+        elif isinstance(field, FlattenedObject):
+            if not field.index or isinstance(field.child_type, Any):
+                mappings[name.strip(".")] = {"type": "object", "enabled": False}
+            else:
+                dynamic.extend(build_templates(f'{name}.*', field.child_type, nested_template=True, index=field.index))
 
         elif isinstance(field, List):
             temp_mappings, temp_dynamic = build_mapping([field.child_type], prefix=path,

--- a/assemblyline/odm/base.py
+++ b/assemblyline/odm/base.py
@@ -672,6 +672,13 @@ class FlattenedObject(Mapping):
     def check(self, value, **kwargs):
         return TypedMapping(self.child_type, self.index, self.store, FLATTENED_OBJECT_SANITIZER, **value)
 
+    def apply_defaults(self, index, store):
+        """Initialize the default settings for the child field."""
+        # First apply the default to the list itself
+        super().apply_defaults(index, store)
+        # Then pass through the initialized values on the list to the child type
+        self.child_type.apply_defaults(self.index, self.store)
+
 
 class Compound(_Field):
     def __init__(self, field_type, **kwargs):

--- a/assemblyline/odm/models/alert.py
+++ b/assemblyline/odm/models/alert.py
@@ -60,7 +60,7 @@ class Alert(odm.Model):
     filtered = odm.Boolean(default=False)                               # Are the alert result filtered
     heuristic = odm.Compound(Heuristic)                                 # Heuristic result block
     label = odm.List(odm.Keyword(), copyto="__text__", default=[])      # List of labels applied to the alert
-    metadata = odm.Mapping(odm.Keyword(), store=False)                  # Metadata submitted with the file
+    metadata = odm.FlattenedObject(default={}, store=False)             # Metadata submitted with the file
     owner = odm.Optional(odm.Keyword())                                 # Owner of the alert
     priority = odm.Optional(odm.Enum(values=PRIORITIES))                # Priority applied to the alert
     reporting_ts = odm.Date()                                           # Time at which the alert was created

--- a/assemblyline/odm/randomizer.py
+++ b/assemblyline/odm/randomizer.py
@@ -26,7 +26,8 @@ laboratory to the marketplace For certain cyber security innovations the Cyber C
 authority We evaluate participating companies new technology and provide feedback in order to assist them in bringing 
 their product to market To learn more about selling or testing an innovation visit the BCIP website""".split()
 WORDS = list(set(WORDS))
-META_KEYS = ["key_a", "key_b", "key_c", "key_d", "key_e", "key_f"]
+MAPPING_KEYS = ["key_a", "key_b", "key_c", "key_d", "key_e", "key_f"]
+META_KEYS = ["ingest.name", "ingest.id", "date", "source", "file.original_ext", "file.original_name"]
 EXT = [
     ".jpg",
     ".doc",
@@ -164,6 +165,10 @@ def get_random_iso_date(epoch: _Optional[float] = None) -> str:
 
 
 def get_random_mapping(field) -> Dict[str, _Any]:
+    return {MAPPING_KEYS[i]: random_data_for_field(field, MAPPING_KEYS[i]) for i in range(random.randint(0, 5))}
+
+
+def get_random_meta(field) -> Dict[str, _Any]:
     return {META_KEYS[i]: random_data_for_field(field, META_KEYS[i]) for i in range(random.randint(0, 5))}
 
 
@@ -253,7 +258,10 @@ def random_data_for_field(field, name: str, minimal: bool = False) -> _Any:
         else:
             return random_model_obj(field.child_type, as_json=True)
     elif isinstance(field, Mapping):
-        return get_random_mapping(field.child_type)
+        if name == 'metadata':
+            return get_random_meta(field.child_type)
+        else:
+            return get_random_mapping(field.child_type)
     elif isinstance(field, Optional):
         if not minimal:
             return random_data_for_field(field.child_type, name)


### PR DESCRIPTION
This patches changes the underlying index template therefor you can't just update a running instance with this patch. We will have to change the index template and reindex all data to keep old data in this new schema.

This should allow submission metadata fields to be queried and should also allow alert metadata to have multilevel data like the submission had. 

I have also modified the create_test_data script so it generates multilevel keys for metadata fields so we can test this properly. To test, do the following:

1. spin up the minimal dev dependency compose file
2. Launch a web server
3. run the create_test_data script with the "full" parameter so it creates sample alerts and submissions with single and multilevel metadata keys.
4. Open the UI in your browser and start doing queries targetting the metadata in the search page.