### PR TITLE
AL-128: Replace StringTable where feasible

### DIFF
--- a/assemblyline/common/str_utils.py
+++ b/assemblyline/common/str_utils.py
@@ -168,21 +168,7 @@ class NamedConstants(object):
         # We implement our own getattr mainly to provide the better exception.
         return self._value_map[s]
 
-
-class StringTable(object):
-
-    def __init__(self, name, string_value_list):
-        self._name = name
-        self._value_map = dict(string_value_list)
-        self._reverse_map = dict([(s[1], s[0]) for s in string_value_list])
-
-        # we also import the list as attributes so things like
-        # tab completion and introspection still work.
-        for s in self._value_map.keys():
-            setattr(self, s, s)
-
-    def name_for_value(self, v):
-        return self._reverse_map[v]
+class EnumMixin(object):
 
     def contains_string(self, s):
         return s in self._reverse_map


### PR DESCRIPTION
 - Replaces StringTable with EnumMixin

Relates to PRs in assemblyline-service-client and assembyline-v4-service.

The goal was to replace uses of the StringTable class with Enums, as StringTable was effectively a python 2 implementation of an enum. The mixin serves to retain certain actions if needed/desired, such as boolean contains string/value methods, as well as improved error reporting.