### PR TITLE
Index fix

### DIFF
--- a/assemblyline/datastore/support/elasticsearch/build.py
+++ b/assemblyline/datastore/support/elasticsearch/build.py
@@ -151,8 +151,7 @@ def build_mapping(field_data, prefix=None, allow_refuse_implicit=True):
                 "mapping": {
                     "type": "keyword",
                     "index": False,
-                    "store": False,
-                    "ignore_malformed": True,
+                    "store": False
                 }
             }
 
@@ -188,8 +187,7 @@ def build_templates(name, field, nested_template=False, index=True) -> list:
                 "mapping": {
                     "type": "nested",
                     "index": field.index,
-                    "store": field.store,
-                    "ignore_malformed": not (field.index or field.store),
+                    "store": field.store
                 }
             }
             if field.copyto:
@@ -219,8 +217,7 @@ def build_templates(name, field, nested_template=False, index=True) -> list:
             "mapping": {
                 "type": "keyword",
                 "index": False,
-                "store": False,
-                "ignore_malformed": True,
+                "store": False
             }
         }
 

--- a/assemblyline/odm/random_data/create_test_data.py
+++ b/assemblyline/odm/random_data/create_test_data.py
@@ -69,4 +69,7 @@ if __name__ == "__main__":
     if "full" in sys.argv:
         create_extra_data(log=logger, ds=datastore)
 
+    if "alerts" in sys.argv:
+        create_alerts(datastore, alert_count=1000, log=logger)
+
     logger.info("\nDone.")


### PR DESCRIPTION
This removes deprecation warnings in elasticsearch because ignore_malformed cannot be used on keyword and nested fields