### PR TITLE
Disable ilm

### DIFF
--- a/assemblyline/datastore/stores/es_store.py
+++ b/assemblyline/datastore/stores/es_store.py
@@ -1251,8 +1251,13 @@ class ESStore(BaseStore):
     }
 
     def __init__(self, hosts, collection_class=ESCollection, archive_access=True):
-        super(ESStore, self).__init__(hosts, collection_class,
-                                      ilm_config=forge.get_config().datastore.ilm.indexes.as_primitives())
+        config = forge.get_config()
+        if config.datastore.ilm.enabled:
+            ilm_config = config.datastore.ilm.indexes.as_primitives()
+        else:
+            ilm_config = {}
+
+        super(ESStore, self).__init__(hosts, collection_class, ilm_config=ilm_config)
         tracer = logging.getLogger('elasticsearch')
         tracer.setLevel(logging.CRITICAL)
 

--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -1,7 +1,7 @@
 from typing import Dict, List
 
 from assemblyline import odm
-from assemblyline.odm.models.service import EnvironmentVariable, DockerConfig
+from assemblyline.odm.models.service import EnvironmentVariable
 
 OAUTH_AUTO_PROPERTY_TYPE = ['access', 'classification', 'role']
 
@@ -309,7 +309,7 @@ DEFAULT_DISPATCHER = {
 # Configuration options regarding data expiry
 @odm.model(index=False, store=False)
 class Expiry(odm.Model):
-    # By turning on batch delete, delete queries are rounded by day therefor
+    # By turning on batch delete, delete queries are rounded by day therefore
     # all delete operation happen at the same time at midnight
     batch_delete = odm.Boolean()
     # Delay in hours that will be applied to the expiry query so we can keep
@@ -353,7 +353,7 @@ class Ingester(odm.Model):
     # How many supplementary files may be added to a submission
     default_max_supplementary: int = odm.Integer()
 
-    # Drop a task altogeather after this many seconds
+    # Drop a task altogether after this many seconds
     expire_after: int = odm.Integer()
     stale_after_seconds: int = odm.Integer()
 
@@ -561,12 +561,14 @@ DEFAULT_ILM_INDEXES = {
 
 @odm.model(index=False, store=False)
 class ILM(odm.Model):
+    enabled = odm.Boolean()
     days_until_archive = odm.Integer()
     indexes = odm.Compound(ILMIndexes, default=DEFAULT_ILM_INDEXES)
 
 
 DEFAULT_ILM = {
     "days_until_archive": 5,
+    "enabled": True,
     "indexes": DEFAULT_ILM_INDEXES
 }
 
@@ -751,7 +753,7 @@ class UI(odm.Model):
     allow_raw_downloads: bool = odm.Boolean()
     # Allow file submissions via url
     allow_url_submissions: bool = odm.Boolean()
-    # Should API calls be audited and saved to a seperate log file?
+    # Should API calls be audited and saved to a separate log file?
     audit: bool = odm.Boolean()
     # Turn on debugging
     debug: bool = odm.Boolean()
@@ -834,7 +836,7 @@ DEFAULT_TAG_TYPES = {
         'attribution.network',
         'av.virus_name',
         'file.config',
-        'techinique.obfuscation',
+        'technique.obfuscation',
     ],
     'behavior': [
         'file.behavior'

--- a/dev/core/docker-compose-sca-upd.yml
+++ b/dev/core/docker-compose-sca-upd.yml
@@ -8,8 +8,8 @@ services:
       FILE_UPDATE_DIRECTORY: /mount/update_root/
     volumes:
       - /tmp/update_data:/mount/update_root/
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
       - /var/run/docker.sock:/var/run/docker.sock  # NOTE, this container has access to docker socket (this is like root)
     command: python3 /opt/alv4/assemblyline-core/assemblyline_core/scaler/run_scaler.py
 
@@ -21,8 +21,8 @@ services:
       FILE_UPDATE_DIRECTORY: /mount/update_root/
     volumes:
       - /tmp/update_data:/mount/update_root/
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
       - /var/run/docker.sock:/var/run/docker.sock  # NOTE, this container has access to docker socket (this is like root)
     command: python3 /opt/alv4/assemblyline-core/assemblyline_core/updater/run_updater.py
 

--- a/dev/core/docker-compose.yml
+++ b/dev/core/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     ports:
       - '5003:5003'
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     working_dir: /opt/alv4/
     command: python3 /opt/alv4/assemblyline-service-server/assemblyline_service_server/app.py
     networks:
@@ -22,8 +22,8 @@ services:
       DEV_ADMIN_PASS: $DEV_ADMIN_PASS
       DEV_USER_PASS: $DEV_USER_PASS
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     working_dir: /opt/alv4/assemblyline-base/assemblyline/odm/random_data/
     command: python3 create_test_data.py nosvc nosigs
 
@@ -33,8 +33,8 @@ services:
     ports:
       - '5000:5000'
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     working_dir: /opt/alv4/assemblyline-ui/assemblyline_ui/
     command: python3 app.py
 
@@ -44,8 +44,8 @@ services:
     ports:
       - '5002:5002'
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     working_dir: /opt/alv4/assemblyline-ui/assemblyline_ui/
     command: python3 socketsrv.py
 
@@ -53,79 +53,79 @@ services:
   al_alerter:
     image: cccs/assemblyline_dev:4.0.17
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     command: python3 /opt/alv4/assemblyline-core/assemblyline_core/alerter/run_alerter.py
 
   # Expiry
   al_expiry:
     image: cccs/assemblyline_dev:4.0.17
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     command: python3 /opt/alv4/assemblyline-core/assemblyline_core/expiry/run_expiry.py
 
   # Elasticsearch Metrics
   al_elastic_metrics:
     image: cccs/assemblyline_dev:4.0.17
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     command: python3 /opt/alv4/assemblyline-core/assemblyline_core/metrics/es_metrics.py
 
   # Metrics aggregator
   al_metrics:
     image: cccs/assemblyline_dev:4.0.17
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     command: python3 /opt/alv4/assemblyline-core/assemblyline_core/metrics/run_metrics_aggregator.py
 
   # Hearbeat manager
   al_heartbeat:
     image: cccs/assemblyline_dev:4.0.17
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     command: python3 /opt/alv4/assemblyline-core/assemblyline_core/metrics/run_heartbeat_manager.py
 
   # Stats aggregator
   al_stats:
     image: cccs/assemblyline_dev:4.0.17
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     command: python3 /opt/alv4/assemblyline-core/assemblyline_core/metrics/run_statistics_aggregator.py
 
   # Workflow
   al_workflow:
     image: cccs/assemblyline_dev:4.0.17
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     command: python3 /opt/alv4/assemblyline-core/assemblyline_core/workflow/run_workflow.py
 
   # Watcher
   al_watcher:
     image: cccs/assemblyline_dev:4.0.17
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     command: python3 /opt/alv4/assemblyline-core/assemblyline_core/watcher/run_watcher.py
 
   al_plumber:
     image: cccs/assemblyline_dev:4.0.17
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     command: python3 /opt/alv4/assemblyline-core/assemblyline_core/plumber/run_plumber.py
 
   # Dispatcher processes
   al_dispatcher_files:
     image: cccs/assemblyline_dev:4.0.17
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     environment:
       SKIP_SERVICE_SETUP: 'true'
     command: python3 /opt/alv4/assemblyline-core/assemblyline_core/dispatching/run_files.py
@@ -133,8 +133,8 @@ services:
   al_dispatcher_submissions:
     image: cccs/assemblyline_dev:4.0.17
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     environment:
       SKIP_SERVICE_SETUP: 'true'
     command: python3 /opt/alv4/assemblyline-core/assemblyline_core/dispatching/run_submissions.py
@@ -143,22 +143,22 @@ services:
   al_ingester_ingest:
     image: cccs/assemblyline_dev:4.0.17
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     command: python3 /opt/alv4/assemblyline-core/assemblyline_core/ingester/run_ingest.py
 
   al_ingester_internal:
     image: cccs/assemblyline_dev:4.0.17
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     command: python3 /opt/alv4/assemblyline-core/assemblyline_core/ingester/run_internal.py
 
   al_ingester_submit:
     image: cccs/assemblyline_dev:4.0.17
     volumes:
-      - ./config/:/etc/assemblyline/
-      - ../../../:/opt/alv4/
+      - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
+      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     command: python3 /opt/alv4/assemblyline-core/assemblyline_core/ingester/run_submit.py
 
 networks:

--- a/dev/depends/docker-compose.yml
+++ b/dev/depends/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   kibana:
     image: docker.elastic.co/kibana/kibana:7.8.0
     volumes:
-      - ./config/kibana.docker.yml:/usr/share/kibana/config/kibana.yml:ro
+      - ${PATH_REWRITE:-.}/config/kibana.docker.yml:/usr/share/kibana/config/kibana.yml:ro
     depends_on:
       elasticsearch:
         condition: service_healthy
@@ -27,7 +27,7 @@ services:
   apm_server:
     image: docker.elastic.co/apm/apm-server:7.8.0
     volumes:
-      - ./config/apm-server.docker.yml:/usr/share/apm-server/apm-server.yml:ro
+      - ${PATH_REWRITE:-.}/config/apm-server.docker.yml:/usr/share/apm-server/apm-server.yml:ro
     command: /bin/bash -c "/usr/local/bin/docker-entrypoint -e -strict.perms=false"
     ports:
       - '8200:8200'
@@ -59,8 +59,8 @@ services:
     volumes:
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./config/filebeat.docker.yml:/usr/share/filebeat/filebeat.yml:ro
-      - ./config/filebeat_policy.json:/usr/share/filebeat/filebeat_policy.json:ro
+      - ${PATH_REWRITE:-.}/config/filebeat.docker.yml:/usr/share/filebeat/filebeat.yml:ro
+      - ${PATH_REWRITE:-.}/config/filebeat_policy.json:/usr/share/filebeat/filebeat_policy.json:ro
     command: filebeat -e -strict.perms=false
     depends_on:
       elasticsearch:
@@ -73,8 +73,8 @@ services:
       ELASTICSEARCH_HOSTS: http://elasticsearch:9200
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./config/metricbeat.docker.yml:/usr/share/metricbeat/metricbeat.yml:ro
-      - ./config/metricbeat_policy.json:/usr/share/metricbeat/metricbeat_policy.json:ro
+      - ${PATH_REWRITE:-.}/config/metricbeat.docker.yml:/usr/share/metricbeat/metricbeat.yml:ro
+      - ${PATH_REWRITE:-.}/config/metricbeat_policy.json:/usr/share/metricbeat/metricbeat_policy.json:ro
     command: metricbeat -e --strict.perms=false
     depends_on:
       elasticsearch:


### PR DESCRIPTION
This patch can completely disable Index Lifecycle Management in Elasticsearch. It turns out that ILM will only work well if you have Hot, warm, cold elastic nodes which none of our deployments actually has. Therefore, ILM could be turned of for the current deployment we have. 