### PR TITLE
Added support for 'list' type service specific parameters

### DIFF
--- a/assemblyline/odm/models/service.py
+++ b/assemblyline/odm/models/service.py
@@ -69,6 +69,7 @@ class SubmissionParams(odm.Model):
     name = odm.Keyword()
     type = odm.Enum(values=['str', 'int', 'list', 'bool'])
     value = odm.Any()
+    list = odm.Optional(odm.Any())
 
 
 @odm.model(index=True, store=False)

--- a/assemblyline/odm/models/service_delta.py
+++ b/assemblyline/odm/models/service_delta.py
@@ -63,6 +63,7 @@ class SubmissionParamsDelta(odm.Model):
     name = odm.Optional(odm.Keyword())
     type = odm.Optional(odm.Enum(values=['str', 'int', 'list', 'bool']))
     value = odm.Optional(odm.Any())
+    list = odm.Optional(odm.Any())
 
 
 @odm.model(index=True, store=False)


### PR DESCRIPTION
Service specific parameters of type list are not supported right now in the DB yet they exist in the UI. This patch adds the missing field.