### PR TITLE
remove % character so apikey doesn't break configparser lib

### DIFF
--- a/assemblyline/common/security.py
+++ b/assemblyline/common/security.py
@@ -16,7 +16,7 @@ SPECIAL = r'[ !#$@%&\'()*+,-./[\\\]^_`{|}~"]'
 PASS_BASIC = [chr(x + 65) for x in range(26)] + \
              [chr(x + 97) for x in range(26)] + \
              [str(x) for x in range(10)] + \
-             ["!", "@", "$", "%", "^", "?", "&", "*", "(", ")"]
+             ["!", "@", "$", "^", "?", "&", "*", "(", ")"]
 
 
 def get_hotp_token(secret, intervals_no):


### PR DESCRIPTION
regarding https://cccs.atlassian.net/browse/AL-769
any % symbols in submit.cfg file must be escaped with another % or follow with (.

https://github.com/python/cpython/blob/723e21a8e79815ae77474d1f21b9847b9c9bdbeb/Lib/configparser.py#L379

Simplest solution would be to exclude % symbol from all generated apikeys.