### PR TITLE
S3 FileStore initialization performance

### DIFF
--- a/assemblyline/filestore/transport/s3.py
+++ b/assemblyline/filestore/transport/s3.py
@@ -65,12 +65,14 @@ class TransportS3(Transport):
         )
 
         bucket_exist = False
-        resp = self.with_retries(self.client.list_buckets)
-
-        for bucket in resp["Buckets"]:
-            if bucket.get("Name", None) == self.bucket:
-                bucket_exist = True
-                break
+        try:
+            self.client.head_bucket(Bucket=self.bucket)
+            bucket_exist = True
+        except ClientError as e:
+            if "404" not in str(e):
+                pass
+            else:
+                raise
 
         if not bucket_exist:
             try:

--- a/assemblyline/filestore/transport/s3.py
+++ b/assemblyline/filestore/transport/s3.py
@@ -66,7 +66,7 @@ class TransportS3(Transport):
 
         bucket_exist = False
         try:
-            self.client.head_bucket(Bucket=self.bucket)
+            self.with_retries(self.client.head_bucket, Bucket=self.bucket)
             bucket_exist = True
         except ClientError as e:
             if "404" not in str(e):


### PR DESCRIPTION
The list buckets operation on FileStore initialization can take a long time if there are a large number of buckets in S3. FileStore in initialized in many locations, but most problematically on `get_filestore` calls in the service API.
https://github.com/CybercentreCanada/assemblyline-base/blob/f7f18c29fda129627740d0499e4b7235f1951552/assemblyline/filestore/transport/s3.py#L68

I have a significant number of rotating buckets for other file-processing in the same S3 instance. The list buckets operation results in a 4 second delay (mostly boto3 parsing datetimes) every time `get_filestore` is called for me. The current code causes submissions to take minutes if there are a lot of extractions:
```python
        bucket_exist = False
        resp = self.with_retries(self.client.list_buckets)

        for bucket in resp["Buckets"]:
            if bucket.get("Name", None) == self.bucket:
                bucket_exist = True
                break
```

A `head_bucket` call would greatly improve performance (particularly for people with multiple buckets already in their S3 instances):
```python
        bucket_exist = False
        try:
            self.client.head_bucket(Bucket=self.bucket)
            bucket_exist = True
        except ClientError as e:
            if "404" not in str(e):
                pass
            else:
                raise
```