### PR TITLE
Fix bulk operator to work well with multi-index setups

### DIFF
--- a/assemblyline/datastore/__init__.py
+++ b/assemblyline/datastore/__init__.py
@@ -27,21 +27,21 @@ def get_object(base, key):
 
 
 class BulkPlan(object):
-    def __init__(self, index, model=None):
-        self.index = index
+    def __init__(self, indexes, model=None):
+        self.indexes = indexes
         self.model = model
         self.operations = []
 
-    def add_delete_operation(self, doc_id):
+    def add_delete_operation(self, doc_id, index=None):
         raise UndefinedFunction("This is the basic BulkPlan object, none of the methods are defined.")
 
-    def add_insert_operation(self, doc_id, doc):
+    def add_insert_operation(self, doc_id, doc, index=None):
         raise UndefinedFunction("This is the basic BulkPlan object, none of the methods are defined.")
 
-    def add_upsert_operation(self, doc_id, doc):
+    def add_upsert_operation(self, doc_id, doc, index=None):
         raise UndefinedFunction("This is the basic BulkPlan object, none of the methods are defined.")
 
-    def add_update_operation(self, doc_id, doc):
+    def add_update_operation(self, doc_id, doc, index=None):
         raise UndefinedFunction("This is the basic BulkPlan object, none of the methods are defined.")
 
     def get_plan_data(self):
@@ -89,6 +89,15 @@ class Collection(object):
         if isinstance(value, list):
             return value[0]
         return value
+
+    @property
+    def index_list(self):
+        """
+        This property contains the list of valid indexes for the current collection.
+
+        :return: list of valid indexes for this collection
+        """
+        return [self.name]
 
     def with_retries(self, func, *args, **kwargs):
         """
@@ -141,7 +150,7 @@ class Collection(object):
 
         :return: The BulkPlan object
         """
-        return self.bulk_plan_class(self.name, model=self.model_class)
+        return self.bulk_plan_class(self.index_list, model=self.model_class)
 
     def commit(self):
         """

--- a/assemblyline/datastore/helper.py
+++ b/assemblyline/datastore/helper.py
@@ -237,10 +237,10 @@ class AssemblylineDatastore(object):
 
         # Add delete operation for submission and cache
         s_plan.add_delete_operation(sid)
-        for t in [x['id'] for x in self.submission_tree.stream_search(f"id:{sid}*", fl="id", as_obj=False)]:
-            st_plan.add_delete_operation(t)
-        for s in [x['id'] for x in self.submission_summary.stream_search(f"id:{sid}*", fl="id", as_obj=False)]:
-            ss_plan.add_delete_operation(s)
+        for x in self.submission_tree.stream_search(f"id:{sid}*", fl="id,_index", as_obj=False):
+            st_plan.add_delete_operation(x['id'], index=x['_index'])
+        for x in self.submission_summary.stream_search(f"id:{sid}*", fl="id,_index", as_obj=False):
+            ss_plan.add_delete_operation(x['id'], index=x['_index'])
 
         # Gather file list
         errors = submission['errors']
@@ -307,13 +307,13 @@ class AssemblylineDatastore(object):
                         new_file_class = cl_engine.min_classification(new_file_class, c)
 
                     # Find the results for that classification and alter them if the new classification does not match
-                    for item in self.result.stream_search(f"id:{f}*", fl="classification,id", as_obj=False):
+                    for item in self.result.stream_search(f"id:{f}*", fl="classification,id,_index", as_obj=False):
                         new_class = cl_engine.max_classification(
                             item.get('classification', cl_engine.UNRESTRICTED), new_file_class)
                         if item.get('classification', cl_engine.UNRESTRICTED) != new_class:
                             data = cl_engine.get_access_control_parts(new_class)
                             data['classification'] = new_class
-                            r_plan.add_update_operation(item['id'], data)
+                            r_plan.add_update_operation(item['id'], data, index=item['_index'])
 
                     # Alter the file classification if the new classification does not match
                     if cur_file['classification'] != new_file_class:

--- a/assemblyline/datastore/stores/es_store.py
+++ b/assemblyline/datastore/stores/es_store.py
@@ -84,13 +84,17 @@ class RetryableIterator(object):
 
 
 class ElasticBulkPlan(BulkPlan):
-    def __init__(self, index, model=None):
-        super().__init__(index, model)
+    def __init__(self, indexes, model=None):
+        super().__init__(indexes, model)
 
-    def add_delete_operation(self, doc_id):
-        self.operations.append(json.dumps({"delete": {"_index": self.index, "_id": doc_id}}))
+    def add_delete_operation(self, doc_id, index=None):
+        if index:
+            self.operations.append(json.dumps({"delete": {"_index": index, "_id": doc_id}}))
+        else:
+            for cur_index in self.indexes:
+                self.operations.append(json.dumps({"delete": {"_index": cur_index, "_id": doc_id}}))
 
-    def add_insert_operation(self, doc_id, doc):
+    def add_insert_operation(self, doc_id, doc, index=None):
         if isinstance(doc, self.model):
             saved_doc = doc.as_primitives(hidden_fields=True)
         elif self.model:
@@ -102,10 +106,10 @@ class ElasticBulkPlan(BulkPlan):
                 saved_doc = deepcopy(doc)
         saved_doc['id'] = doc_id
 
-        self.operations.append(json.dumps({"create": {"_index": self.index, "_id": doc_id}}))
+        self.operations.append(json.dumps({"create": {"_index": index or self.indexes[0], "_id": doc_id}}))
         self.operations.append(json.dumps(saved_doc))
 
-    def add_upsert_operation(self, doc_id, doc):
+    def add_upsert_operation(self, doc_id, doc, index=None):
         if isinstance(doc, self.model):
             saved_doc = doc.as_primitives(hidden_fields=True)
         elif self.model:
@@ -117,10 +121,11 @@ class ElasticBulkPlan(BulkPlan):
                 saved_doc = deepcopy(doc)
         saved_doc['id'] = doc_id
 
-        self.operations.append(json.dumps({"update": {"_index": self.index, "_id": doc_id}}))
+        self.operations.append(json.dumps({"update": {"_index": index or self.indexes[0], "_id": doc_id}}))
         self.operations.append(json.dumps({"doc": saved_doc, "doc_as_upsert": True}))
 
-    def add_update_operation(self, doc_id, doc):
+    def add_update_operation(self, doc_id, doc, index=None):
+
         if isinstance(doc, self.model):
             saved_doc = doc.as_primitives(hidden_fields=True)
         elif self.model:
@@ -131,8 +136,13 @@ class ElasticBulkPlan(BulkPlan):
             else:
                 saved_doc = deepcopy(doc)
 
-        self.operations.append(json.dumps({"update": {"_index": self.index, "_id": doc_id}}))
-        self.operations.append(json.dumps({"doc": saved_doc}))
+        if index:
+            self.operations.append(json.dumps({"update": {"_index": index, "_id": doc_id}}))
+            self.operations.append(json.dumps({"doc": saved_doc}))
+        else:
+            for cur_index in self.indexes:
+                self.operations.append(json.dumps({"update": {"_index": cur_index, "_id": doc_id}}))
+                self.operations.append(json.dumps({"doc": saved_doc}))
 
     def get_plan_data(self):
         return "\n".join(self.operations)
@@ -608,6 +618,8 @@ class ESCollection(Collection):
             else:
                 if 'id' in fields:
                     source['id'] = item_id
+                if '_index' in fields and '_index' in result:
+                    source['_index'] = result["_index"]
 
                 return source
 


### PR DESCRIPTION
This patch allows the BulkPlan operator to delete and update IDs from ILM controlled indexes. It also allows bulk operations to be targetted to a specific index to speed things up a bit.