### PR TITLE
Duplicate datastore entries

### DIFF
--- a/assemblyline/common/bundling.py
+++ b/assemblyline/common/bundling.py
@@ -204,7 +204,7 @@ def create_bundle(sid, working_dir=WORK_DIR):
 
 # noinspection PyBroadException,PyProtectedMember
 def import_bundle(path, working_dir=WORK_DIR, min_classification=Classification.UNRESTRICTED, allow_incomplete=False):
-    with forge.get_datastore() as datastore:
+    with forge.get_datastore(archive_access=True) as datastore:
         current_working_dir = os.path.join(working_dir, get_random_id())
         res_file = os.path.join(current_working_dir, "results.json")
         try:

--- a/assemblyline/datastore/helper.py
+++ b/assemblyline/datastore/helper.py
@@ -996,7 +996,7 @@ class AssemblylineDatastore(object):
     def save_or_freshen_file(self, sha256, fileinfo, expiry, classification,
                              cl_engine=forge.get_classification(), redis=None):
         with Lock(f'save-or-freshen-file-{sha256}', 5, host=redis):
-            current_fileinfo = self.ds.file.get(sha256, as_obj=False) or {}
+            current_fileinfo = self.ds.file.get(sha256, as_obj=False, force_archive_access=True) or {}
 
             # Remove control fields from file info and update current file info
             for x in ['classification', 'expiry_ts', 'seen', 'archive_ts']:
@@ -1027,4 +1027,4 @@ class AssemblylineDatastore(object):
                 str(classification)
             )
             current_fileinfo['classification'] = classification
-            self.ds.file.save(sha256, current_fileinfo)
+            self.ds.file.save(sha256, current_fileinfo, force_archive_access=True)


### PR DESCRIPTION
Fix for AL-994 where duplicated file entries and results can be created because some system components don't have access to the archive.

The idea behind this patch is to give temporary access to warm/cold indexes to sensitive operations where files, results, and alerts are saved to the system to prevent that we end up with duplicate documents.