### PR TITLE
Default to ILM being turned off (dev)

### DIFF
--- a/assemblyline/common/custom.magic
+++ b/assemblyline/common/custom.magic
@@ -1,115 +1,100 @@
+# Assemblyline Cart files
 0	string	CART
 >0x6	quad	0	custom: archive/cart
-
+# IDA Analysis files
 0	string	IDA1\000\000	custom: code/ida
-
+# JFIF (JPEG) files
 0	string	JFIF\000\001	custom: image/jpg
-
+# RTF Files
 0	string	{\\rt	custom: document/office/rtf
-
+# Flash files
 0	string	ZWS custom: archive/audiovisual/flash
-
 0	string	CWS custom: archive/audiovisual/flash
-
 0	string	FWS custom: audiovisual/flash
-
+# MHTML files
 0		string
 >&0     regex/10        \^(Subject|MIME)
 >>0x10 	search/0x100    multipart/related
 >>>0x50	search/0x300	urn:schemas-microsoft-com:office    custom: document/office/mhtml
-
+# VBE files
 0   string
 >&0     regex/20        \^#@~\\^[^=]{6}==     custom: code/vbe
-
+# VBS files
 0   string
 >&0     regex/300        \(On\ Error\ Resume\ Next|WScript\.CreateObject)     custom: code/vbs
-
+# Android
+# XML compiled files
 0	string	\003\000\010\000	custom: android/xml
-
+# Resources files
 0	string	\002\000\014\000	custom: android/resource
-
+# DEX files
 0	string	dex\n	custom: android/dex
-
+# Games sound files
+# FSB
 0   string  FSB     custom: audiovisual/fsb
-
+# AFS
 0	string	AFS2 	custom: audiovisual/afs
-
+# ACB
 0	string	@UTF\000 	custom: audiovisual/acb
-
+# Textures
 0	string	PVR custom: image/texture/powervr
-
 0	string	KA3D	custom: image/texture/ka3d
-
 0	string	RVIO	custom: image/texture/rvio
-
 0	string	PKM 	custom: image/texture/pkm
-
 0	string	\253KTX\040 	custom: image/texture/ktx
-
 0   string  4\000\000\000
 >&0 search/0x40 PVR!	custom: font/texture/pvr
-
+# Opengl code (gles)
 0       search/0x100     technique
 >&0     search/0x100     pass
 >>&0    regex/0x100      VertexShader|PixelShader   custom: code/gles
-
+# Opengl code (glsl)
 0    regex/0x100      COMPILEVS|COMPILEPS
 >&0 regex/0x100      vec2|vec3|vec4   custom: code/glsl
-
 1   string      technique    custom: code/glsl
 1   string      renderpath    custom: code/glsl
 1   string      material    custom: code/glsl
 1   string      texture    custom: code/glsl
-
+# Animations
 0	string	ibcc 	custom: code/animation/ccb
-
+# Java manifest file
 0   string   Manifest-Version:   custom: java/manifest
-
+# Java signature file
 0   string   Signature-Version:  custom: java/signature
-
+# RSA Certs
 0   string
 >0  search/0x20 \006\011\052\206\110\206\367\015\001\007\002\240    custom: certificate/rsa
-
+# Java Jbdiff files
 0   string  \x001jbdiff     custom: java/jbdiff
-
+# Resources files
 0    long 4
 >8   byte 0                 custom: resource/pak
-
 0    long 4
 >8   byte 1                 custom: resource/pak
-
 0    long 4
 >8   byte 2                 custom: resource/pak
-
 0	 string	CPK\040\377     custom: resource/cpk
-
 0	 string	DTRZ            custom: resource/dz
-
 0   string
 >(0.S-2)   string  Mesh   custom: resource/sbm
-
 0   string  SC\000\000\000\001\000\000\000\020  custom: resource/sc
-
 0   string  CCZ!\000\000\000\001\000\000\000\000  custom: resource/ccz
-
 0   string  EB\000\003\000\000\000  custom: resource/big
-
 0   string  PTCH\007\001  custom: resource/ptc
-
 0       string  SBle
 >16     string  MRAH     custom: resource/sbr
-
 0   string
 >&0     regex/40        [0-9]\\.[0-9]\\.[0-9][a-zA-Z][0-9]     custom: resource/unity
-
+# Database files
+# DBF
 0   string  DBPF\002\000\000\000\001    custom: db/dbf
-
+# sqlite
 0   string  SQLite\040format\040    custom: db/sqlite
-
+# WSF code files
 0      string         \<job
 >&0    search/0x30    \<script\ language   custom: code/wsf
-
+# TCPDump capture
 0   short   0x3C4D
 >&0 short   0xA1B2        custom: network\tcpdump
-
+# Email
 0   string  DKIM-Signature:     custom: document/email

--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -291,7 +291,7 @@ class Alerter(odm.Model):
 
 
 DEFAULT_ALERTER = {
-    "alert_ttl": 0,
+    "alert_ttl": 90,
     "constant_alert_fields": ["alert_id", "file", "ts"],
     "default_group_field": "file.sha256",
     "delay": 300,
@@ -586,7 +586,7 @@ class ILM(odm.Model):
 
 DEFAULT_ILM = {
     "days_until_archive": 5,
-    "enabled": True,
+    "enabled": False,
     "indexes": DEFAULT_ILM_INDEXES
 }
 
@@ -906,7 +906,7 @@ class Submission(odm.Model):
 DEFAULT_SUBMISSION = {
     'default_max_extracted': 500,
     'default_max_supplementary': 500,
-    'dtl': 0,
+    'dtl': 30,
     'max_extraction_depth': 6,
     'max_file_size': 104857600,
     'max_metadata_length': 4096,

--- a/assemblyline/odm/models/user_settings.py
+++ b/assemblyline/odm/models/user_settings.py
@@ -24,6 +24,6 @@ class UserSettings(odm.Model):                                      # User's def
     service_spec = odm.Mapping(odm.Keyword(), default={})             # Default service specific settings
     services = odm.Compound(ServiceSelection, default={})             # Default service selection
     submission_view = odm.Enum(values=VIEWS, default="report")        # Default view for completed submissions
-    ttl = odm.Integer(default=0)                                      # Default submission Time to Live (days)
+    ttl = odm.Integer(default=30)                                     # Default submission Time to Live (days)
     ui4 = odm.Boolean(default=False)                                  # Reroute to UI 4
     ui4_ask = odm.Boolean(default=True)                               # Ask user if he wants to try UI 4

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -1,14 +1,16 @@
 
+import hashlib
 import os
 import pytest
 import random
 import re
+import subprocess
+import tempfile
 
+from baseconv import BASE62_ALPHABET
+from cart import pack_stream, get_metadata_only
 from copy import deepcopy
 from io import BytesIO
-
-from assemblyline.odm.models.heuristic import Heuristic
-from baseconv import BASE62_ALPHABET
 
 from assemblyline.common import forge
 from assemblyline.common.attack_map import attack_map, software_map
@@ -19,12 +21,14 @@ from assemblyline.common.dict_utils import flatten, unflatten, recursive_update,
 from assemblyline.common.entropy import calculate_partition_entropy
 from assemblyline.common.heuristics import InvalidHeuristicException, service_heuristic_to_result_heuristic
 from assemblyline.common.hexdump import hexdump
+from assemblyline.common.identify import fileinfo
 from assemblyline.common.isotime import now_as_iso, iso_to_epoch, epoch_to_local, local_to_epoch, epoch_to_iso, now, \
     now_as_local
 from assemblyline.common.iprange import is_ip_reserved, is_ip_private
 from assemblyline.common.security import get_random_password, get_password_hash, verify_password
 from assemblyline.common.str_utils import safe_str, translate_str
 from assemblyline.common.uid import get_random_id, get_id_from_data, TINY, SHORT, MEDIUM, LONG
+from assemblyline.odm.models.heuristic import Heuristic
 from assemblyline.odm.randomizer import random_model_obj, get_random_word
 
 
@@ -217,6 +221,46 @@ def test_hexdump():
         assert c[1] in "abcdef1234567890"
         assert c[2] == " "
     assert line[59:59+2] == "  "
+
+
+def test_identify():
+    # Setup test data
+    aaaa = f"{'A' * 10000}".encode()
+    sha256 = hashlib.sha256(aaaa).hexdigest()
+
+    # Prep temp file
+    _, input_path = tempfile.mkstemp()
+    output_path = f"{input_path}.cart"
+
+    try:
+        # Write temp file
+        with open(input_path, 'wb') as oh:
+            oh.write(aaaa)
+
+        # Create a cart file
+        with open(output_path, 'wb') as oh:
+            with open(input_path, 'rb') as ih:
+                pack_stream(ih, oh, {'name': 'test_identify.a'})
+
+        # Validate the cart file created
+        meta = get_metadata_only(output_path)
+        assert meta.get("sha256", None) == sha256
+
+        # Validate identify file detection
+        info = fileinfo(output_path)
+        assert info.get("type", None) == "archive/cart"
+
+        # Validate identify hashing
+        output_sha256 = subprocess.check_output(['sha256sum', output_path])[:64].decode()
+        assert info.get("sha256", None) == output_sha256
+    finally:
+        # Cleanup output file
+        if os.path.exists(output_path):
+            os.unlink(output_path)
+
+        # Cleanup input file
+        if os.path.exists(input_path):
+            os.unlink(input_path)
 
 
 def test_iprange():


### PR DESCRIPTION
This PR makes changes to the default config to have ILM turned off since ILM is basically only useful when an Elastic cluster has hot/warm/cold storage setup. 

It also fixes an issue where the index definition would get corrupted during a reindex call which will be used to turn off ILM on systems that previously had it on.