### PR TITLE
Default to ILM being turned off.

### DIFF
--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -291,7 +291,7 @@ class Alerter(odm.Model):
 
 
 DEFAULT_ALERTER = {
-    "alert_ttl": 0,
+    "alert_ttl": 90,
     "constant_alert_fields": ["alert_id", "file", "ts"],
     "default_group_field": "file.sha256",
     "delay": 300,
@@ -586,7 +586,7 @@ class ILM(odm.Model):
 
 DEFAULT_ILM = {
     "days_until_archive": 5,
-    "enabled": True,
+    "enabled": False,
     "indexes": DEFAULT_ILM_INDEXES
 }
 
@@ -906,7 +906,7 @@ class Submission(odm.Model):
 DEFAULT_SUBMISSION = {
     'default_max_extracted': 500,
     'default_max_supplementary': 500,
-    'dtl': 0,
+    'dtl': 30,
     'max_extraction_depth': 6,
     'max_file_size': 104857600,
     'max_metadata_length': 4096,

--- a/assemblyline/odm/models/user_settings.py
+++ b/assemblyline/odm/models/user_settings.py
@@ -24,6 +24,6 @@ class UserSettings(odm.Model):                                      # User's def
     service_spec = odm.Mapping(odm.Keyword(), default={})             # Default service specific settings
     services = odm.Compound(ServiceSelection, default={})             # Default service selection
     submission_view = odm.Enum(values=VIEWS, default="report")        # Default view for completed submissions
-    ttl = odm.Integer(default=0)                                      # Default submission Time to Live (days)
+    ttl = odm.Integer(default=30)                                     # Default submission Time to Live (days)
     ui4 = odm.Boolean(default=False)                                  # Reroute to UI 4
     ui4_ask = odm.Boolean(default=True)                               # Ask user if he wants to try UI 4


### PR DESCRIPTION
This PR makes changes to the default config to have ILM turned off since ILM is basically only useful when an Elastic cluster has hot/warm/cold storage setup. 

It also fixes an issue where the index definition would get corrupted during a reindex call which will be used to turn off ILM on systems that previously had it on.