### PR TITLE
Work around for msoffcrypto failure

### DIFF
--- a/assemblyline/common/identify.py
+++ b/assemblyline/common/identify.py
@@ -768,13 +768,14 @@ def fileinfo(path: str) -> Dict:
 
     if data['type'] in ['document/office/word', 'document/office/excel',
                         'document/office/powerpoint', 'document/office/unknown']:
-        msoffcrypto_obj = None
         try:
             msoffcrypto_obj = msoffcrypto.OfficeFile(open(path, "rb"))
+            if msoffcrypto_obj and msoffcrypto_obj.is_encrypted():
+                data['type'] = 'document/office/passwordprotected'
         except Exception:
+            # If msoffcrypto can't handle the file to confirm that it is/isn't password protected,
+            # then it's not meant to be. Moving on!
             pass
-        if msoffcrypto_obj and msoffcrypto_obj.is_encrypted():
-            data['type'] = 'document/office/passwordprotected'
 
     if not recognized.get(data['type'], False) and not cart_metadata_set:
         data['type'] = 'unknown'


### PR DESCRIPTION
`msoffcrypto.is_encrypted()` would throw `AssertionError` for some reason on the occasional Office file. The files that throw this error are not password protected so we don't care if we properly validate that indeed the files are not password protected in this scenario.