### PR TITLE
Regex Tweak in Identify.py

### DIFF
--- a/assemblyline/common/identify.py
+++ b/assemblyline/common/identify.py
@@ -130,7 +130,7 @@ WEAK_INDICATORS = {
     'code/jscript': [rb'new[ \t]+ActiveXObject\(', rb'Scripting\.Dictionary'],
     'code/pdfjs': [rb'xfa\.((resolve|create)Node|datasets|form)', rb'\.oneOfChild'],
     'code/vbs': [
-        rb'(^|\n)*[ \t]*(Dim |Sub |Loop |Attribute |End Sub|Function |End Function )',
+        rb'(^|\n)*[ ]{0,1000}[\t]*(Dim |Sub |Loop |Attribute |End Sub|Function |End Function )',
         b'CreateObject',
         b'WScript',
         b'window_onload',


### PR DESCRIPTION
Putting a limit on leading whitespaces in regex to avoid catastrophic backtracking.

This regex issue was causing a specific sample that had 1000s of whitespaces in its file contents to take > 1 minute in identify.py which then caused the API to send a 502 gateway timeout and limited (~0) logs regarding the error.