### PR TITLE
Pass additional labels k8s

### DIFF
--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -509,7 +509,7 @@ class Scaler(odm.Model):
     cpu_overallocation: float = odm.Float(default=1)
     memory_overallocation: float = odm.Float(default=1)
     # Additional labels to be applied to deployments in kubernetes
-    additional_labels: List[str] = odm.Optional(odm.Mapping(odm.Text()))
+    additional_labels: Dict[str, str] = odm.Optional(odm.Mapping(odm.Text()))
 
 
 DEFAULT_SCALER = {

--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -508,6 +508,8 @@ class Scaler(odm.Model):
     # only available for docker hosts, not kubernetes
     cpu_overallocation: float = odm.Float(default=1)
     memory_overallocation: float = odm.Float(default=1)
+    # Additional labels to be applied to deployments in kubernetes
+    additional_labels: List[str] = odm.Optional(odm.Mapping(odm.Text()))
 
 
 DEFAULT_SCALER = {


### PR DESCRIPTION
Because of the current state of Rancher, I need to pass "io.cattle.field/appId: 'assemblyline'" as a label to new deployments otherwise we aren't able to reach service-server (and probably other things I haven't found yet relating to netpols.)

Adding an additional config under scaler for passing these extra labels (maybe better idea to put in a higher scope like config.core.*?)

Related core: https://github.com/CybercentreCanada/assemblyline-core/pull/71