### PR TITLE
Hotfix/safer index commands

### DIFF
--- a/assemblyline/datastore/__init__.py
+++ b/assemblyline/datastore/__init__.py
@@ -79,6 +79,7 @@ class Collection(object):
     def __init__(self, datastore, name, model_class=None, validate=True):
         self.datastore = datastore
         self.name = name
+        self.index_name = f"{name}_hot"
         self.model_class = model_class
         self.validate = validate
         self.bulk_plan_class = BulkPlan

--- a/assemblyline/run/cli.py
+++ b/assemblyline/run/cli.py
@@ -851,20 +851,30 @@ class ALCommandLineInterface(cmd.Cmd):  # pylint:disable=R0904
 
     def do_index(self, args):
         """
-        Perform operations on the search index
+        Perform operations on the database index.
+
+        ** Do not use these operations unless you absolutely have to as they may slow down
+           considerably your system and some of these operations may result in dataloss if
+           something went wrong in the middle of it.
 
         Usage:
-            index commit     [<safe>] [<bucket>]
-                  reindex    [<safe>] [<bucket>]
-                  fix_shards [<safe>] [<bucket>]
-                  fix_ilm    [<safe>] [<bucket>]
+            index commit        [<safe>] [<bucket>]
+                  reindex       [<safe>] [<bucket>]
+                  fix_ilm       [<safe>] [<bucket>]
+                  fix_replicas  [<safe>] [<bucket>]
+                  fix_shards    [<safe>] [<bucket>]
 
         Actions:
             commit        Force datastore to commit the specified index
-            reindex       Force a reindex of the sepcified index (this can be really slow)
-            fix_ilm       Fix ILM on specified indices (this can be really slow and prevents writes on the index)
+            reindex       Force a reindex of the sepcified index
+                             ** This operation is really slow because it re-index all documents
+            fix_ilm       Fix ILM on specified indices
+                             ** This operation can be really slow when going from an ILM setup to a hot
+                                archive only setup because it will copy the archive to hot index
             fix_replicas  Fix replica count on specified indices
-            fix_shards    Fix sharding on specified indices (this can be really slow and prevents writes on the index)
+            fix_shards    Fix sharding on specified indices
+                             ** This operation can be slow and will prevent data from being written
+                                the cluster while it is hapenning.
 
         Parameters:
             <safe>       Does not validate the model [optional]


### PR DESCRIPTION
This PR forces hot indexes to use aliases so re-sharding and reindexing operation can be run on live system without data loss. This changes a lot how datastore interacts with elasticsearch. 

Don't just approve the PR without understanding what it does, question everything that is done. 