### PR TITLE
hotfix/nested

### DIFF
--- a/assemblyline/datastore/support/elasticsearch/build.py
+++ b/assemblyline/datastore/support/elasticsearch/build.py
@@ -189,13 +189,20 @@ def build_templates(name, field, nested_template=False, index=True) -> list:
                 "match": f"{name}",
                 "mapping": {
                     "type": "nested",
-                    "index": field.index,
-                    "store": field.store
+                    "properties": {
+                        "*": {
+                            "type": "keyword",
+                            "index": field.index,
+                            "store": field.store,
+                            "ignore_above": 8191
+                        }
+                    }
+
                 }
             }
             if field.copyto:
                 assert len(field.copyto) == 1
-                main_template['mapping']['copy_to'] = field.copyto[0]
+                main_template['mapping']["properties"]["*"]['copy_to'] = field.copyto[0]
 
             return [{f"nested_{name}": main_template}]
         else:


### PR DESCRIPTION
Fix nested fields to behave properly. 

1. Removes warning thrown by elastic 
2. Maps nested field as keyword so they are easier to search properly
3. Allow nested fields to follow index, store and copy_to values