### PR TITLE
Switch from pyroute2 to pyroute2.core

### DIFF
--- a/assemblyline/common/net.py
+++ b/assemblyline/common/net.py
@@ -5,7 +5,7 @@ import uuid
 from random import randint
 
 import netifaces as nif
-import pyroute2
+import pr2modules.iproute as iproute
 
 from assemblyline.common.net_static import TLDS_ALPHA_BY_DOMAIN
 
@@ -94,7 +94,7 @@ def get_random_mac(seperator: str = ':') -> str:
 def get_route_to(dst: str) -> str:
     ret_val = None
     try:
-        with pyroute2.IPRoute() as ipr:
+        with iproute.IPRoute() as ipr:
             for k, v in ipr.route('get', dst=dst)[0]['attrs']:
                 if k == "RTA_PREFSRC":
                     ret_val = v

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         'boto3',
         'pysftp',
         'netifaces',
-        'pyroute2',
+        'pyroute2.core',
         'redis',
         'requests',
         'elasticsearch>=7.0.0,<8.0.0,!=7.0.3',  # 7.0.3 is excluded due to an error


### PR DESCRIPTION
The newest pyroute2 version is split into separate packages. See https://github.com/svinota/pyroute2/discussions/786 and https://github.com/svinota/pyroute2/discussions/796.
Assemblyline only uses IPRoute from pyroute2.core. Currently the pyroute2 and pyroute2-minimal meta packages have import bugs related to not having importlib-metadata installed on python3.7 https://github.com/svinota/pyroute2/issues/797. This is causing an error in Frankenstrings which uses functions in net.py to validate network strings. This is fixed by switching to pyroute2.core which doesn't use importlib-metadata and minimizes our dependencies.