### PR TITLE
hotfix/nested_guessing

### DIFF
--- a/assemblyline/datastore/stores/es_store.py
+++ b/assemblyline/datastore/stores/es_store.py
@@ -17,7 +17,7 @@ from assemblyline.datastore.exceptions import ILMException, MultiKeyError, Searc
     DataStoreException
 from assemblyline.datastore.support.elasticsearch.build import back_mapping, build_mapping
 from assemblyline.datastore.support.elasticsearch.schemas import (default_dynamic_templates, default_index,
-                                                                  default_mapping)
+                                                                  default_mapping, default_dynamic_strings)
 
 write_block_settings = {"settings": {"index.blocks.write": True}}
 write_unblock_settings = {"settings": {"index.blocks.write": None}}
@@ -1415,6 +1415,7 @@ class ESCollection(Collection):
         if self.model_class:
             mappings['properties'], mappings['dynamic_templates'] = \
                 build_mapping(self.model_class.fields().values())
+            mappings['dynamic_templates'].insert(0, default_dynamic_strings)
         else:
             mappings['dynamic_templates'] = deepcopy(default_dynamic_templates)
 

--- a/assemblyline/datastore/support/elasticsearch/build.py
+++ b/assemblyline/datastore/support/elasticsearch/build.py
@@ -188,21 +188,9 @@ def build_templates(name, field, nested_template=False, index=True) -> list:
             main_template = {
                 "match": f"{name}",
                 "mapping": {
-                    "type": "nested",
-                    "properties": {
-                        "*": {
-                            "type": "keyword",
-                            "index": field.index,
-                            "store": field.store,
-                            "ignore_above": 8191
-                        }
-                    }
-
+                    "type": "nested"
                 }
             }
-            if field.copyto:
-                assert len(field.copyto) == 1
-                main_template['mapping']["properties"]["*"]['copy_to'] = field.copyto[0]
 
             return [{f"nested_{name}": main_template}]
         else:

--- a/assemblyline/datastore/support/elasticsearch/schemas.py
+++ b/assemblyline/datastore/support/elasticsearch/schemas.py
@@ -30,9 +30,9 @@ default_index = {
             },
             "normalizer": {
                 "lowercase_normalizer": {
-                  "type": "custom",
-                  "char_filter": [],
-                  "filter": ["lowercase"]
+                    "type": "custom",
+                    "char_filter": [],
+                    "filter": ["lowercase"]
                 }
             }
         }
@@ -44,6 +44,16 @@ default_mapping = {
     'dynamic': True,
     'properties': {
         '__text__': {'type': 'text'},
+    }
+}
+
+default_dynamic_strings = {
+    "strings_as_keywords": {
+        "match_mapping_type": "string",
+        "mapping": {
+            "type": "keyword",
+            "ignore_above": 8191
+        }
     }
 }
 


### PR DESCRIPTION
Let nested field be guessed using the first value and enforce strings as keywords.

It turns out that you cannot use wildcards to set inner properties of nested type so instead we will just use dynamic guessing but will enforce keywords when string types are detected.