### PR TITLE
Add document/office/onenote to the list of recognized types

### DIFF
--- a/assemblyline/common/constants.py
+++ b/assemblyline/common/constants.py
@@ -146,6 +146,7 @@ RECOGNIZED_TYPES = {
     'document/office/powerpoint': True,
     'document/office/passwordprotected': True,
     'document/office/ole': True,
+    'document/office/onenote': True,
     'document/office/rtf': True,
     'document/office/unknown': True,
     'document/office/visio': True,


### PR DESCRIPTION
Missed this the first time