### PR TITLE
add registry_type to DockerConfig* in odm

### DIFF
--- a/assemblyline/odm/models/service.py
+++ b/assemblyline/odm/models/service.py
@@ -22,6 +22,7 @@ class DockerConfig(odm.Model):
     image: str = odm.Keyword()                       # Complete name of the Docker image with tag, may include registry
     registry_username = odm.Optional(odm.Keyword())  # The username to use when pulling the image
     registry_password = odm.Optional(odm.Keyword())  # The password or token to use when pulling the image
+    registry_type = odm.Enum(values=["docker", "harbor"], default='docker')  # The type of registry (Docker, Harbor)
     ports: List[str] = odm.List(odm.Keyword(), default=[])
     ram_mb: int = odm.Integer(default=512)
     ram_mb_min: int = odm.Integer(default=128)

--- a/assemblyline/odm/models/service_delta.py
+++ b/assemblyline/odm/models/service_delta.py
@@ -16,7 +16,7 @@ class DockerConfigDelta(odm.Model):
     image = odm.Optional(odm.Keyword())  # The docker image and tag, optionally including registry in the normal way
     registry_username = odm.Optional(odm.Keyword())  # The username to use when pulling the image
     registry_password = odm.Optional(odm.Keyword())  # The password or token to use when pulling the image
-    registry_type = odm.Enum(values=["docker", "harbor"], default='docker')  # The type of registry (Docker, Harbor)
+    registry_type = odm.Optional(odm.Enum(values=["docker", "harbor"]))  # The type of registry (Docker, Harbor)
     ports = odm.Optional(odm.List(odm.Keyword()))
     ram_mb = odm.Optional(odm.Integer())
     ram_mb_min = odm.Optional(odm.Integer())

--- a/assemblyline/odm/models/service_delta.py
+++ b/assemblyline/odm/models/service_delta.py
@@ -16,6 +16,7 @@ class DockerConfigDelta(odm.Model):
     image = odm.Optional(odm.Keyword())  # The docker image and tag, optionally including registry in the normal way
     registry_username = odm.Optional(odm.Keyword())  # The username to use when pulling the image
     registry_password = odm.Optional(odm.Keyword())  # The password or token to use when pulling the image
+    registry_type = odm.Enum(values=["docker", "harbor"], default='docker')  # The type of registry (Docker, Harbor)
     ports = odm.Optional(odm.List(odm.Keyword()))
     ram_mb = odm.Optional(odm.Integer())
     ram_mb_min = odm.Optional(odm.Integer())


### PR DESCRIPTION
Needed for PRs:
core - https://github.com/CybercentreCanada/assemblyline-core/pull/228
ui_fe - https://github.com/CybercentreCanada/assemblyline-ui-frontend/pull/81

List of supported container registry types, will default to 'docker'.