### PR TITLE
K8S development directory

### DIFF
--- a/dev/k8s/README
+++ b/dev/k8s/README
@@ -1,5 +1,0 @@
-- use K8S appliance for setup
-- ensure registry addon for microk8s is enabled (check: GET localhost:32000/v2/_catalog)
-- run local_dev_containers.sh script with tag as param
-- run helm install|upgrade using new tag in values.yaml
-- use Lens or commandline to monitor status of deployment

--- a/dev/k8s/README
+++ b/dev/k8s/README
@@ -1,0 +1,5 @@
+- use K8S appliance for setup
+- ensure registry addon for microk8s is enabled (check: GET localhost:32000/v2/_catalog)
+- run local_dev_containers.sh script with tag as param
+- run helm install|upgrade using new tag in values.yaml
+- use Lens or commandline to monitor status of deployment

--- a/dev/k8s/README.md
+++ b/dev/k8s/README.md
@@ -4,6 +4,29 @@
   - Test: curl localhost:32000/v2/_catalog
 - When ready to build, run local_dev_containers.sh script with tag as parameter.
 - Run helm install|upgrade using new tags in values.yaml.
-- Use Lens, command-line, or VS Code's [Kubernetes](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) extension to monitor status of and/or debug deployment
+- Use Lens or kubectl to monitor status of deployment
 - You can create local service-base images by passing an optional build-arg on a docker build command otherwise will pull latest.
   - ie. docker build . -f service-base.Dockerfile --build-arg build_no=dev0
+- Debugging: Visual Code's [Bridge to Kubernetes](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.mindaro) &
+[Kubernetes](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) extensions
+  - TODO: figure out how to use it with Scaler/Updater that make calls to Kubernetes API
+  - Add to settings.json (assuming using microk8s installed from snap):
+    '''
+        "vs-kubernetes": {
+          "vs-kubernetes.namespace": "al",
+          "vs-kubernetes.kubectl-path": "/snap/kubectl/current/kubectl",
+          "vs-kubernetes.helm-path": "/snap/helm/current/helm",
+          "vs-kubernetes.minikube-path": "/snap/bin/microk8s",
+          "vs-kubernetes.kubectlVersioning": "user-provided",
+          "vs-kubernetes.outputFormat": "yaml",
+          "vs-kubernetes.kubeconfig": "/var/snap/microk8s/current/credentials/client.config",
+          "vs-kubernetes.knownKubeconfigs": [],
+          "vs-kubernetes.autoCleanupOnDebugTerminate": false,
+          "vs-kubernetes.nodejs-autodetect-remote-root": true,
+          "vs-kubernetes.nodejs-remote-root": "",
+          "vs-kubernetes.nodejs-debug-port": 9229,
+          "vs-kubernetes.local-tunnel-debug-provider": "",
+          "checkForMinikubeUpgrade": false,
+          "imageBuildTool": "Docker"
+      }
+    '''

--- a/dev/k8s/README.md
+++ b/dev/k8s/README.md
@@ -1,7 +1,7 @@
 # Assemblyline Dev Setup (Kubernetes)
 - Follow steps in [K8S appliance](https://github.com/CybercentreCanada/assemblyline-helm-chart/tree/master/appliance) for local Kubernetes setup
-- Enable registry add-on for microk8s
-  - check: GET localhost:32000/v2/_catalog)
+- Enable registry add-on for microk8s (other registries can be used like Harbor but involves more setup which isn't covered here)
+  - Test: curl localhost:32000/v2/_catalog
 - When ready to build, run local_dev_containers.sh script with tag as parameter
-- run helm install|upgrade using new tag in values.yaml
-- use Lens or command-line to monitor status of deployment
+- Run helm install|upgrade using new tag in values.yaml
+- Use Lens or command-line to monitor status of deployment

--- a/dev/k8s/README.md
+++ b/dev/k8s/README.md
@@ -1,32 +1,7 @@
 # Assemblyline Dev Setup (Kubernetes)
-- Follow steps in [K8S appliance](https://github.com/CybercentreCanada/assemblyline-helm-chart/tree/master/appliance) for local Kubernetes setup
-- Enable registry add-on for microK8S (other registries can be used like Harbor but involves more setup which isn't covered here)
-  - Test: curl localhost:32000/v2/_catalog
+- Run setup script for [alv4_setup](https://github.com/cccs-sgaron/alv4_setup) with -k flag
 - When ready to build, run local_dev_containers.sh script with tag as parameter.
-- Run helm install|upgrade using new tags in values.yaml.
+- Run helm upgrade using new tags in values.yaml.
 - Use Lens or kubectl to monitor status of deployment
 - You can create local service-base images by passing an optional build-arg on a docker build command otherwise will pull latest.
   - ie. docker build . -f service-base.Dockerfile --build-arg build_no=dev0
-- Debugging: Visual Code's [Bridge to Kubernetes](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.mindaro) &
-[Kubernetes](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) extensions
-  - Add the following to settings.json (assuming using microk8s installed from snap):
-    ```
-    "vs-kubernetes": {
-      "vs-kubernetes.namespace": "al",
-      "vs-kubernetes.kubectl-path": "/snap/kubectl/current/kubectl",
-      "vs-kubernetes.helm-path": "/snap/helm/current/helm",
-      "vs-kubernetes.minikube-path": "/snap/bin/microk8s",
-      "vs-kubernetes.kubectlVersioning": "user-provided",
-      "vs-kubernetes.outputFormat": "yaml",
-      "vs-kubernetes.kubeconfig": "/var/snap/microk8s/current/credentials/client.config",
-      "vs-kubernetes.knownKubeconfigs": [],
-      "vs-kubernetes.autoCleanupOnDebugTerminate": false,
-      "vs-kubernetes.nodejs-autodetect-remote-root": true,
-      "vs-kubernetes.nodejs-remote-root": "",
-      "vs-kubernetes.nodejs-debug-port": 9229,
-      "vs-kubernetes.local-tunnel-debug-provider": "",
-      "checkForMinikubeUpgrade": false,
-      "imageBuildTool": "Docker"
-    }
-    ```
-  - Specific to Updater/Scaler: You need to provide an environment variable in your launch targets called 'KUBECONFIG' that points to where your kubeconfig file is.

--- a/dev/k8s/README.md
+++ b/dev/k8s/README.md
@@ -1,0 +1,7 @@
+# Assemblyline Dev Setup (Kubernetes)
+- Follow steps in [K8S appliance](https://github.com/CybercentreCanada/assemblyline-helm-chart/tree/master/appliance) for local Kubernetes setup
+- Enable registry add-on for microk8s
+  - check: GET localhost:32000/v2/_catalog)
+- When ready to build, run local_dev_containers.sh script with tag as parameter
+- run helm install|upgrade using new tag in values.yaml
+- use Lens or command-line to monitor status of deployment

--- a/dev/k8s/README.md
+++ b/dev/k8s/README.md
@@ -1,7 +1,9 @@
 # Assemblyline Dev Setup (Kubernetes)
 - Follow steps in [K8S appliance](https://github.com/CybercentreCanada/assemblyline-helm-chart/tree/master/appliance) for local Kubernetes setup
-- Enable registry add-on for microk8s (other registries can be used like Harbor but involves more setup which isn't covered here)
+- Enable registry add-on for microK8S (other registries can be used like Harbor but involves more setup which isn't covered here)
   - Test: curl localhost:32000/v2/_catalog
 - When ready to build, run local_dev_containers.sh script with tag as parameter
 - Run helm install|upgrade using new tag in values.yaml
-- Use Lens or command-line to monitor status of deployment
+- Use Lens, command-line, or VS Code's [Kubernetes](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) extension to monitor status of and/or debug deployment
+- You can create local service-base images by passing a build-arg on a docker build command
+  - ie. docker build . -f service-base.Dockerfile --build-arg dev0

--- a/dev/k8s/README.md
+++ b/dev/k8s/README.md
@@ -2,8 +2,8 @@
 - Follow steps in [K8S appliance](https://github.com/CybercentreCanada/assemblyline-helm-chart/tree/master/appliance) for local Kubernetes setup
 - Enable registry add-on for microK8S (other registries can be used like Harbor but involves more setup which isn't covered here)
   - Test: curl localhost:32000/v2/_catalog
-- When ready to build, run local_dev_containers.sh script with tag as parameter
-- Run helm install|upgrade using new tag in values.yaml
+- When ready to build, run local_dev_containers.sh script with tag as parameter.
+- Run helm install|upgrade using new tags in values.yaml.
 - Use Lens, command-line, or VS Code's [Kubernetes](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) extension to monitor status of and/or debug deployment
-- You can create local service-base images by passing a build-arg on a docker build command
-  - ie. docker build . -f service-base.Dockerfile --build-arg dev0
+- You can create local service-base images by passing an optional build-arg on a docker build command otherwise will pull latest.
+  - ie. docker build . -f service-base.Dockerfile --build-arg build_no=dev0

--- a/dev/k8s/README.md
+++ b/dev/k8s/README.md
@@ -11,22 +11,22 @@
 [Kubernetes](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) extensions
   - TODO: figure out how to use it with Scaler/Updater that make calls to Kubernetes API
   - Add to settings.json (assuming using microk8s installed from snap):
-    '''
-        "vs-kubernetes": {
-          "vs-kubernetes.namespace": "al",
-          "vs-kubernetes.kubectl-path": "/snap/kubectl/current/kubectl",
-          "vs-kubernetes.helm-path": "/snap/helm/current/helm",
-          "vs-kubernetes.minikube-path": "/snap/bin/microk8s",
-          "vs-kubernetes.kubectlVersioning": "user-provided",
-          "vs-kubernetes.outputFormat": "yaml",
-          "vs-kubernetes.kubeconfig": "/var/snap/microk8s/current/credentials/client.config",
-          "vs-kubernetes.knownKubeconfigs": [],
-          "vs-kubernetes.autoCleanupOnDebugTerminate": false,
-          "vs-kubernetes.nodejs-autodetect-remote-root": true,
-          "vs-kubernetes.nodejs-remote-root": "",
-          "vs-kubernetes.nodejs-debug-port": 9229,
-          "vs-kubernetes.local-tunnel-debug-provider": "",
-          "checkForMinikubeUpgrade": false,
-          "imageBuildTool": "Docker"
-      }
-    '''
+    ```
+    "vs-kubernetes": {
+      "vs-kubernetes.namespace": "al",
+      "vs-kubernetes.kubectl-path": "/snap/kubectl/current/kubectl",
+      "vs-kubernetes.helm-path": "/snap/helm/current/helm",
+      "vs-kubernetes.minikube-path": "/snap/bin/microk8s",
+      "vs-kubernetes.kubectlVersioning": "user-provided",
+      "vs-kubernetes.outputFormat": "yaml",
+      "vs-kubernetes.kubeconfig": "/var/snap/microk8s/current/credentials/client.config",
+      "vs-kubernetes.knownKubeconfigs": [],
+      "vs-kubernetes.autoCleanupOnDebugTerminate": false,
+      "vs-kubernetes.nodejs-autodetect-remote-root": true,
+      "vs-kubernetes.nodejs-remote-root": "",
+      "vs-kubernetes.nodejs-debug-port": 9229,
+      "vs-kubernetes.local-tunnel-debug-provider": "",
+      "checkForMinikubeUpgrade": false,
+      "imageBuildTool": "Docker"
+    }
+    ```

--- a/dev/k8s/README.md
+++ b/dev/k8s/README.md
@@ -9,8 +9,7 @@
   - ie. docker build . -f service-base.Dockerfile --build-arg build_no=dev0
 - Debugging: Visual Code's [Bridge to Kubernetes](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.mindaro) &
 [Kubernetes](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) extensions
-  - TODO: figure out how to use it with Scaler/Updater that make calls to Kubernetes API
-  - Add to settings.json (assuming using microk8s installed from snap):
+  - Add the following to settings.json (assuming using microk8s installed from snap):
     ```
     "vs-kubernetes": {
       "vs-kubernetes.namespace": "al",
@@ -30,3 +29,4 @@
       "imageBuildTool": "Docker"
     }
     ```
+  - Specific to Updater/Scaler: You need to provide an environment variable in your launch targets called 'KUBECONFIG' that points to where your kubeconfig file is.

--- a/dev/k8s/local_dev.Dockerfile
+++ b/dev/k8s/local_dev.Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-slim-buster
 
-ENV PYTHONPATH /opt/alv4/assemblyline-base:/opt/alv4/assemblyline-core:/opt/alv4/assemblyline-service-server:/opt/alv4/assemblyline-service-client:/opt/alv4/assemblyline-ui
+ENV PYTHONPATH /opt/alv4/assemblyline-base:/opt/alv4/assemblyline-core:/opt/alv4/assemblyline-service-server:/opt/alv4/assemblyline-service-client:/opt/alv4/assemblyline-ui:/opt/alv4/assemblyline-v4-service:/opt/alv4/assemblyline-service-client
 
 # SSDEEP pkg requirments
 RUN apt-get update -yy \
@@ -33,8 +33,17 @@ RUN pip install -e ./assemblyline_client[test]
 COPY assemblyline-service-server assemblyline-service-server
 RUN pip install -e ./assemblyline-service-server[test]
 
+COPY assemblyline-service-client assemblyline-service-client
+RUN pip install -e ./assemblyline-service-client[test]
+
+COPY assemblyline-v4-service assemblyline-v4-service
+RUN pip install -e ./assemblyline-v4-service[test]
+
+
 RUN pip uninstall -y assemblyline
 RUN pip uninstall -y assemblyline_core
 RUN pip uninstall -y assemblyline_ui
 RUN pip uninstall -y assemblyline_service_server
 RUN pip uninstall -y assemblyline_client
+RUN pip uninstall -y assemblyline_service_client
+RUN pip uninstall -y assemblyline_v4_service

--- a/dev/k8s/local_dev.Dockerfile
+++ b/dev/k8s/local_dev.Dockerfile
@@ -25,7 +25,7 @@ COPY assemblyline-core assemblyline-core
 RUN pip install -e ./assemblyline-core[test]
 
 COPY assemblyline-ui assemblyline-ui
-RUN pip install -e ./assemblyline-ui[test]
+RUN pip install -e ./assemblyline-ui[socketio,test]
 
 COPY assemblyline_client assemblyline_client
 RUN pip install -e ./assemblyline_client[test]

--- a/dev/k8s/local_dev.Dockerfile
+++ b/dev/k8s/local_dev.Dockerfile
@@ -17,7 +17,10 @@ RUN mkdir -p /var/log/assemblyline
 RUN mkdir -p /opt/alv4
 WORKDIR /opt/alv4
 
-#
+# Optional package for debugging with VS Code; needed for Debug (Attach)
+# https://github.com/Azure/vscode-kubernetes-tools/blob/master/debug-on-kubernetes.md
+RUN pip install debugpy
+
 COPY assemblyline-base assemblyline-base
 RUN pip install -e ./assemblyline-base[test]
 

--- a/dev/k8s/local_dev.Dockerfile
+++ b/dev/k8s/local_dev.Dockerfile
@@ -1,0 +1,40 @@
+FROM python:3.9-slim-buster
+
+ENV PYTHONPATH /opt/alv4/assemblyline-base:/opt/alv4/assemblyline-core:/opt/alv4/assemblyline-service-server:/opt/alv4/assemblyline-service-client:/opt/alv4/assemblyline-ui
+
+# SSDEEP pkg requirments
+RUN apt-get update -yy \
+    && apt-get install -yy build-essential libffi-dev libfuzzy-dev libldap2-dev libsasl2-dev libmagic1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create Assemblyline source directory
+RUN mkdir -p /etc/assemblyline
+RUN mkdir -p /var/cache/assemblyline
+RUN mkdir -p /var/lib/assemblyline
+RUN mkdir -p /var/lib/assemblyline/flowjs
+RUN mkdir -p /var/lib/assemblyline/bundling
+RUN mkdir -p /var/log/assemblyline
+RUN mkdir -p /opt/alv4
+WORKDIR /opt/alv4
+
+#
+COPY assemblyline-base assemblyline-base
+RUN pip install -e ./assemblyline-base[test]
+
+COPY assemblyline-core assemblyline-core
+RUN pip install -e ./assemblyline-core[test]
+
+COPY assemblyline-ui assemblyline-ui
+RUN pip install -e ./assemblyline-ui[test]
+
+COPY assemblyline_client assemblyline_client
+RUN pip install -e ./assemblyline_client[test]
+
+COPY assemblyline-service-server assemblyline-service-server
+RUN pip install -e ./assemblyline-service-server[test]
+
+RUN pip uninstall -y assemblyline
+RUN pip uninstall -y assemblyline_core
+RUN pip uninstall -y assemblyline_ui
+RUN pip uninstall -y assemblyline_service_server
+RUN pip uninstall -y assemblyline_client

--- a/dev/k8s/local_dev_containers.sh
+++ b/dev/k8s/local_dev_containers.sh
@@ -6,8 +6,7 @@ echo "Building $1"
 
 # Build & push main container
 (docker build . -t localhost:32000/cccs/assemblyline:$1 -f assemblyline-base/dev/k8s/local_dev.Dockerfile)
-(docker push localhost:32000/cccs/assemblyline:$1)
-
+(docker tag localhost:32000/cccs/assemblyline:$1 localhost:32000/cccs/assemblyline:latest)
 
 # Build core containers
 cd assemblyline-base/dev/k8s/

--- a/dev/k8s/local_dev_containers.sh
+++ b/dev/k8s/local_dev_containers.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -ex
+
+# Script assumes running from context of alv4 to pull in base, core, service-server, client, ui dirs for main container build
+
+echo "Building $1"
+
+# Build & push main container
+(docker build . -t localhost:32000/cccs/assemblyline:$1 -f assemblyline-base/dev/k8s/local_dev.Dockerfile)
+(docker push localhost:32000/cccs/assemblyline:$1)
+
+
+# Build core containers
+(docker tag localhost:32000/cccs/assemblyline:$1 localhost:32000/cccs/assemblyline-core:$1)
+(docker build . -t localhost:32000/cccs/assemblyline-ui:$1 -f assemblyline-base/dev/k8s/ui.Dockerfile --build-arg build_no=$1)
+(docker build . -t localhost:32000/cccs/assemblyline-socketio:$1 -f assemblyline-base/dev/k8s/socketio.Dockerfile --build-arg build_no=$1)
+(docker build . -t localhost:32000/cccs/assemblyline-service-server:$1 -f assemblyline-base/dev/k8s/service-server.Dockerfile --build-arg build_no=$1)
+
+# Push core local registry
+(docker push localhost:32000/cccs/assemblyline-core:$1)
+(docker push localhost:32000/cccs/assemblyline-ui:$1)
+(docker push localhost:32000/cccs/assemblyline-socketio:$1)
+(docker push localhost:32000/cccs/assemblyline-service-server:$1)

--- a/dev/k8s/local_dev_containers.sh
+++ b/dev/k8s/local_dev_containers.sh
@@ -15,7 +15,7 @@ echo "Building $1"
 (docker build . -t localhost:32000/cccs/assemblyline-socketio:$1 -f assemblyline-base/dev/k8s/socketio.Dockerfile --build-arg build_no=$1)
 (docker build . -t localhost:32000/cccs/assemblyline-service-server:$1 -f assemblyline-base/dev/k8s/service-server.Dockerfile --build-arg build_no=$1)
 
-# Push core local registry
+# Push core to local registry
 (docker push localhost:32000/cccs/assemblyline-core:$1)
 (docker push localhost:32000/cccs/assemblyline-ui:$1)
 (docker push localhost:32000/cccs/assemblyline-socketio:$1)

--- a/dev/k8s/local_dev_containers.sh
+++ b/dev/k8s/local_dev_containers.sh
@@ -10,10 +10,11 @@ echo "Building $1"
 
 
 # Build core containers
+cd assemblyline-base/dev/k8s/
 (docker tag localhost:32000/cccs/assemblyline:$1 localhost:32000/cccs/assemblyline-core:$1)
-(docker build . -t localhost:32000/cccs/assemblyline-ui:$1 -f assemblyline-base/dev/k8s/ui.Dockerfile --build-arg build_no=$1)
-(docker build . -t localhost:32000/cccs/assemblyline-socketio:$1 -f assemblyline-base/dev/k8s/socketio.Dockerfile --build-arg build_no=$1)
-(docker build . -t localhost:32000/cccs/assemblyline-service-server:$1 -f assemblyline-base/dev/k8s/service-server.Dockerfile --build-arg build_no=$1)
+(docker build . -t localhost:32000/cccs/assemblyline-ui:$1 -f ui.Dockerfile --build-arg build_no=$1)
+(docker build . -t localhost:32000/cccs/assemblyline-socketio:$1 -f socketio.Dockerfile --build-arg build_no=$1)
+(docker build . -t localhost:32000/cccs/assemblyline-service-server:$1 -f service-server.Dockerfile --build-arg build_no=$1)
 
 # Push core to local registry
 (docker push localhost:32000/cccs/assemblyline-core:$1)

--- a/dev/k8s/local_dev_containers.sh
+++ b/dev/k8s/local_dev_containers.sh
@@ -20,3 +20,7 @@ cd assemblyline-base/dev/k8s/
 (docker push localhost:32000/cccs/assemblyline-ui:$1)
 (docker push localhost:32000/cccs/assemblyline-socketio:$1)
 (docker push localhost:32000/cccs/assemblyline-service-server:$1)
+
+# Build service-base
+(docker build . -t cccs/assemblyline-v4-service-base:$1 -f service-base.Dockerfile --build-arg build_no=$1)
+(docker tag cccs/assemblyline-v4-service-base:$1 cccs/assemblyline-v4-service-base:latest)

--- a/dev/k8s/service-base.Dockerfile
+++ b/dev/k8s/service-base.Dockerfile
@@ -10,5 +10,4 @@ ENV CONTAINER_MODE true
 RUN mkdir -p /opt/al_service
 RUN touch /opt/al_service/__init__.py
 
-USER assemblyline
 CMD ["python", "/opt/alv4/assemblyline-v4-service/docker/process_handler.py"]

--- a/dev/k8s/service-base.Dockerfile
+++ b/dev/k8s/service-base.Dockerfile
@@ -10,4 +10,4 @@ ENV CONTAINER_MODE true
 RUN mkdir -p /opt/al_service
 RUN touch /opt/al_service/__init__.py
 
-CMD ["python", "-m", "debugpy", "--listen", "localhost:5678","/opt/alv4/assemblyline-v4-service/docker/process_handler.py"]
+CMD ["python", "-m", "debugpy", "--listen", "localhost:5678", "-m", "/opt/alv4/assemblyline-v4-service/docker/process_handler.py"]

--- a/dev/k8s/service-base.Dockerfile
+++ b/dev/k8s/service-base.Dockerfile
@@ -1,0 +1,14 @@
+ARG build_no=dev0
+FROM localhost:32000/cccs/assemblyline:$build_no
+
+# Setup environment varibles
+ENV PYTHONPATH $PYTHONPATH:/opt/al_service
+ENV SERVICE_API_HOST http://al_service_server:5003
+ENV SERVICE_API_AUTH_KEY ThisIsARandomAuthKey...ChangeMe!
+ENV CONTAINER_MODE true
+
+RUN mkdir -p /opt/al_service
+RUN touch /opt/al_service/__init__.py
+
+USER assemblyline
+CMD ["python", "/opt/alv4/assemblyline-v4-service/docker/process_handler.py"]

--- a/dev/k8s/service-base.Dockerfile
+++ b/dev/k8s/service-base.Dockerfile
@@ -10,4 +10,4 @@ ENV CONTAINER_MODE true
 RUN mkdir -p /opt/al_service
 RUN touch /opt/al_service/__init__.py
 
-CMD ["python", "/opt/alv4/assemblyline-v4-service/docker/process_handler.py"]
+CMD ["python", "-m", "debugpy", "--listen", "localhost:5678","/opt/alv4/assemblyline-v4-service/docker/process_handler.py"]

--- a/dev/k8s/service-base.Dockerfile
+++ b/dev/k8s/service-base.Dockerfile
@@ -1,4 +1,4 @@
-ARG build_no=dev0
+ARG build_no=latest
 FROM localhost:32000/cccs/assemblyline:$build_no
 
 # Setup environment varibles

--- a/dev/k8s/service-server.Dockerfile
+++ b/dev/k8s/service-server.Dockerfile
@@ -1,4 +1,4 @@
 ARG build_no=latest
 FROM localhost:32000/cccs/assemblyline:$build_no
 
-CMD ["gunicorn", "assemblyline_service_server.patched:app", "--config=python:assemblyline_service_server.gunicorn_config", "--worker-class", "gevent"]
+CMD ["python", "-m", "debugpy", "--listen", "localhost:5678", "-m", "gunicorn", "assemblyline_service_server.patched:app", "--config=python:assemblyline_service_server.gunicorn_config", "--worker-class", "gevent"]

--- a/dev/k8s/service-server.Dockerfile
+++ b/dev/k8s/service-server.Dockerfile
@@ -1,0 +1,4 @@
+ARG build_no=dev0
+FROM localhost:32000/cccs/assemblyline:$build_no
+
+CMD ["gunicorn", "assemblyline_service_server.patched:app", "--config=python:assemblyline_service_server.gunicorn_config", "--worker-class", "gevent"]

--- a/dev/k8s/service-server.Dockerfile
+++ b/dev/k8s/service-server.Dockerfile
@@ -1,4 +1,4 @@
-ARG build_no=dev0
+ARG build_no=latest
 FROM localhost:32000/cccs/assemblyline:$build_no
 
 CMD ["gunicorn", "assemblyline_service_server.patched:app", "--config=python:assemblyline_service_server.gunicorn_config", "--worker-class", "gevent"]

--- a/dev/k8s/socketio.Dockerfile
+++ b/dev/k8s/socketio.Dockerfile
@@ -1,0 +1,4 @@
+ARG build_no=dev0
+FROM localhost:32000/cccs/assemblyline:$build_no
+
+CMD ["gunicorn", "-b", ":5002", "-w", "1", "-k", "geventwebsocket.gunicorn.workers.GeventWebSocketWorker", "assemblyline_ui.socketsrv:app"]

--- a/dev/k8s/socketio.Dockerfile
+++ b/dev/k8s/socketio.Dockerfile
@@ -1,4 +1,4 @@
 ARG build_no=latest
 FROM localhost:32000/cccs/assemblyline:$build_no
 
-CMD ["gunicorn", "-b", ":5002", "-w", "1", "-k", "geventwebsocket.gunicorn.workers.GeventWebSocketWorker", "assemblyline_ui.socketsrv:app"]
+CMD ["python", "-m", "debugpy", "--listen", "localhost:5678", "-m", "gunicorn", "-b", ":5002", "-w", "1", "-k", "geventwebsocket.gunicorn.workers.GeventWebSocketWorker", "assemblyline_ui.socketsrv:app"]

--- a/dev/k8s/socketio.Dockerfile
+++ b/dev/k8s/socketio.Dockerfile
@@ -1,4 +1,4 @@
-ARG build_no=dev0
+ARG build_no=latest
 FROM localhost:32000/cccs/assemblyline:$build_no
 
 CMD ["gunicorn", "-b", ":5002", "-w", "1", "-k", "geventwebsocket.gunicorn.workers.GeventWebSocketWorker", "assemblyline_ui.socketsrv:app"]

--- a/dev/k8s/ui.Dockerfile
+++ b/dev/k8s/ui.Dockerfile
@@ -1,4 +1,4 @@
 ARG build_no=latest
 FROM localhost:32000/cccs/assemblyline:$build_no
 
-CMD ["gunicorn", "assemblyline_ui.patched:app", "--config=python:assemblyline_ui.gunicorn_config", "--worker-class", "gevent"]
+CMD ["python", "-m", "debugpy", "--listen", "localhost:5678", "-m", "gunicorn", "assemblyline_ui.patched:app", "--config=python:assemblyline_ui.gunicorn_config", "--worker-class", "gevent"]

--- a/dev/k8s/ui.Dockerfile
+++ b/dev/k8s/ui.Dockerfile
@@ -1,4 +1,4 @@
-ARG build_no=dev0
+ARG build_no=latest
 FROM localhost:32000/cccs/assemblyline:$build_no
 
 CMD ["gunicorn", "assemblyline_ui.patched:app", "--config=python:assemblyline_ui.gunicorn_config", "--worker-class", "gevent"]

--- a/dev/k8s/ui.Dockerfile
+++ b/dev/k8s/ui.Dockerfile
@@ -1,0 +1,4 @@
+ARG build_no=dev0
+FROM localhost:32000/cccs/assemblyline:$build_no
+
+CMD ["gunicorn", "assemblyline_ui.patched:app", "--config=python:assemblyline_ui.gunicorn_config", "--worker-class", "gevent"]

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         'elastic-apm[flask]!=6.3.0,!=6.3.1,!=6.3.2',  # Exclude broken elastic APM version
         'cython',
         'docker',
-        'kubernetes',
+        'kubernetes<18',
         'notifications-python-client',
         # Blacklist a bad release of the azure library until a release newer than that comes out
         'azure-storage-blob!=12.4.0',


### PR DESCRIPTION
Meant to act similar to how we run docker-compose for development with Docker so we can test for Kubernetes-specific features (ie. persistent-service-update)

For main infrastructure, we'll use the local registry add-on in microK8S and the script will build and push to the local registry when run with a tag parameter.

Improvements can definitely be made to this dev setup, so feedback is wanted!
Related to: https://cccs.atlassian.net/browse/AL-1325

Related PRs:
alv4_setup: https://github.com/cccs-sgaron/alv4_setup/pull/1
helm-chart: https://github.com/CybercentreCanada/assemblyline-helm-chart/pull/20