### PR TITLE
Removing 'color/color scheme' as options

### DIFF
--- a/assemblyline/common/identify.py
+++ b/assemblyline/common/identify.py
@@ -372,7 +372,7 @@ tl_patterns = [
     ['java', r'jar |java'],
     ['code',
      r'Autorun|HTML |KML |LLVM |SGML |Visual C|XML |awk|batch |bytecode|perl|php|program|python'
-     r'|ruby|color scheme|script text exe|shell script|tcl'],
+     r'|ruby|script text exe|shell script|tcl'],
     ['network', r'capture'],
     ['unknown', r'CoreFoundation|Dreamcast|KEYBoard|OSF/Rose|Zope|quota|uImage'],
     ['unknown', r'disk|file[ ]*system|floppy|tape'],
@@ -381,7 +381,7 @@ tl_patterns = [
      r'|sound|tracker|video|voice data'],
     ['executable', r'803?86|COFF|ELF|Mach-O|ia32|executable|kernel|library|libtool|object'],
     ['unknown', r'Emulator'],
-    ['image', r'DjVu|Surface|XCursor|bitmap|cursor|color|font|graphics|icon|image|jpeg'],
+    ['image', r'DjVu|Surface|XCursor|bitmap|cursor|font|graphics|icon|image|jpeg'],
     ['archive',
      r'BinHex|InstallShield CAB|Transport Neutral Encapsulation Format|archive data|compress|mcrypt'
      r'|MS Windows HtmlHelp Data|current ar archive|cpio archive|ISO 9660'],

--- a/test/test_identify.py
+++ b/test/test_identify.py
@@ -664,7 +664,7 @@ def test_sl_to_tl(sl, tl):
      ('java', r'jar |java'),
      ('code',
       r'Autorun|HTML |KML |LLVM |SGML |Visual C|XML |awk|batch |bytecode|perl|php|program|python'
-      r'|ruby|color scheme|script text exe|shell script|tcl'),
+      r'|ruby|script text exe|shell script|tcl'),
      ('network', r'capture'),
      ('unknown', r'CoreFoundation|Dreamcast|KEYBoard|OSF/Rose|Zope|quota|uImage'),
      ('unknown', r'disk|file[ ]*system|floppy|tape'),
@@ -673,7 +673,7 @@ def test_sl_to_tl(sl, tl):
       r'|sound|tracker|video|voice data'),
      ('executable', r'803?86|COFF|ELF|Mach-O|ia32|executable|kernel|library|libtool|object'),
      ('unknown', r'Emulator'),
-     ('image', r'DjVu|Surface|XCursor|bitmap|cursor|color|font|graphics|icon|image|jpeg'),
+     ('image', r'DjVu|Surface|XCursor|bitmap|cursor|font|graphics|icon|image|jpeg'),
      ('archive',
       r'BinHex|InstallShield CAB|Transport Neutral Encapsulation Format|archive data|compress|mcrypt'
       r'|MS Windows HtmlHelp Data|current ar archive|cpio archive|ISO 9660'),


### PR DESCRIPTION
For some reason, libmagic on Debian Buster returns details about the temperature and colour when it is labelling a file. This causes issues in our method of identifying .evtx, .pcap and .exe files. SO if I remove the mentions of color from how we label files, we can avoid this.

Closes https://cccs.atlassian.net/browse/AL-1364