### PR TITLE
Hotfix/any mappings

### DIFF
--- a/assemblyline/datastore/__init__.py
+++ b/assemblyline/datastore/__init__.py
@@ -693,10 +693,10 @@ class Collection(Generic[ModelType]):
 
         matching = set(fields.keys()) & set(model.keys())
         for field_name in matching:
-            if fields[field_name]['indexed'] != model[field_name].index:
-                raise RuntimeError(f"Field {field_name} didn't have the expected indexing value.")
-            if fields[field_name]['stored'] != model[field_name].store:
-                raise RuntimeError(f"Field {field_name} didn't have the expected store value.")
+            if fields[field_name]['indexed'] != model[field_name].index and model[field_name].index:
+                raise RuntimeError(f"Field {field_name} should be indexed but is not.")
+            if fields[field_name]['stored'] != model[field_name].store and model[field_name].store:
+                raise RuntimeError(f"Field {field_name} should be stored but is not.")
 
             possible_field_types = self.__get_possible_fields(model[field_name].__class__)
 

--- a/assemblyline/datastore/support/elasticsearch/build.py
+++ b/assemblyline/datastore/support/elasticsearch/build.py
@@ -27,7 +27,8 @@ __type_mapping = {
     MD5: 'keyword',
     Platform: 'keyword',
     Processor: 'keyword',
-    FlattenedObject: 'nested'
+    FlattenedObject: 'nested',
+    Any: 'keyword',
 }
 __analyzer_mapping = {
     SSDeepHash: 'text_fuzzy',

--- a/assemblyline/datastore/support/elasticsearch/build.py
+++ b/assemblyline/datastore/support/elasticsearch/build.py
@@ -155,8 +155,7 @@ def build_mapping(field_data, prefix=None, allow_refuse_implicit=True):
             mappings[name.strip(".")] = {
                 "type": "keyword",
                 "index": False,
-                "store": False,
-                "ignore_above": 8191
+                "store": False
             }
 
         else:

--- a/assemblyline/datastore/support/elasticsearch/build.py
+++ b/assemblyline/datastore/support/elasticsearch/build.py
@@ -27,8 +27,7 @@ __type_mapping = {
     MD5: 'keyword',
     Platform: 'keyword',
     Processor: 'keyword',
-    FlattenedObject: 'nested',
-    Any: 'keyword',
+    FlattenedObject: 'nested'
 }
 __analyzer_mapping = {
     SSDeepHash: 'text_fuzzy',

--- a/assemblyline/datastore/support/elasticsearch/build.py
+++ b/assemblyline/datastore/support/elasticsearch/build.py
@@ -27,7 +27,8 @@ __type_mapping = {
     MD5: 'keyword',
     Platform: 'keyword',
     Processor: 'keyword',
-    FlattenedObject: 'nested'
+    FlattenedObject: 'nested',
+    Any: 'keyword'
 }
 __analyzer_mapping = {
     SSDeepHash: 'text_fuzzy',
@@ -41,7 +42,7 @@ __normalizer_mapping = {
 back_mapping = {v: k for k, v in __type_mapping.items() if k not in [Enum, Classification, UUID, IP, Domain, URI,
                                                                      URIPath, MAC, PhoneNumber, SSDeepHash, Email,
                                                                      SHA1, SHA256, MD5, Platform, Processor,
-                                                                     ClassificationString]}
+                                                                     ClassificationString, Any]}
 back_mapping.update({x: Keyword for x in set(__analyzer_mapping.values())})
 
 

--- a/assemblyline/datastore/support/elasticsearch/build.py
+++ b/assemblyline/datastore/support/elasticsearch/build.py
@@ -149,18 +149,15 @@ def build_mapping(field_data, prefix=None, allow_refuse_implicit=True):
                 dynamic.extend(build_templates(f'{name}.*', field.child_type, index=field.index))
 
         elif isinstance(field, Any):
-            field_template = {
-                "path_match": name,
-                "mapping": {
-                    "type": "keyword",
-                    "index": False,
-                    "store": False
-                }
-            }
-
             if field.index or field.store:
                 raise ValueError(f"Any may not be indexed or stored: {name}")
-            dynamic.append({f"{name}_tpl": field_template})
+
+            mappings[name.strip(".")] = {
+                "type": "keyword",
+                "index": False,
+                "store": False,
+                "ignore_above": 8191
+            }
 
         else:
             raise NotImplementedError(f"Unknown type for elasticsearch schema: {field.__class__}")

--- a/assemblyline/odm/base.py
+++ b/assemblyline/odm/base.py
@@ -793,6 +793,9 @@ class Model:
             if skip_mappings and isinstance(sub_field, Mapping):
                 continue
 
+            elif isinstance(sub_field, Any):
+                continue
+
             elif isinstance(sub_field, (List, Optional, Compound)) and sub_name != "":
                 out.update(Model._recurse_fields(".".join([name, sub_name]), sub_field.child_type,
                                                  show_compound, skip_mappings,
@@ -824,6 +827,8 @@ class Model:
         for name, field in cls.__dict__.items():
             if isinstance(field, _Field):
                 if skip_mappings and isinstance(field, Mapping):
+                    continue
+                if isinstance(field, Any):
                     continue
                 out.update(Model._recurse_fields(name, field, show_compound, skip_mappings,
                                                  multivalued=isinstance(field, List)))

--- a/assemblyline/odm/base.py
+++ b/assemblyline/odm/base.py
@@ -793,9 +793,6 @@ class Model:
             if skip_mappings and isinstance(sub_field, Mapping):
                 continue
 
-            elif isinstance(sub_field, Any):
-                continue
-
             elif isinstance(sub_field, (List, Optional, Compound)) and sub_name != "":
                 out.update(Model._recurse_fields(".".join([name, sub_name]), sub_field.child_type,
                                                  show_compound, skip_mappings,
@@ -827,8 +824,6 @@ class Model:
         for name, field in cls.__dict__.items():
             if isinstance(field, _Field):
                 if skip_mappings and isinstance(field, Mapping):
-                    continue
-                if isinstance(field, Any):
                     continue
                 out.update(Model._recurse_fields(name, field, show_compound, skip_mappings,
                                                  multivalued=isinstance(field, List)))

--- a/assemblyline/odm/models/service_delta.py
+++ b/assemblyline/odm/models/service_delta.py
@@ -69,7 +69,7 @@ class SubmissionParamsDelta(odm.Model):
     type = odm.Optional(odm.Enum(values=['str', 'int', 'list', 'bool']))
     value = odm.Optional(odm.Any())
     list = odm.Optional(odm.Any())
-    hide = odm.Optional(odm.Any())
+    hide = odm.Optional(odm.Boolean())
 
 
 @odm.model(index=True, store=False)

--- a/test/test_datastore_odm.py
+++ b/test/test_datastore_odm.py
@@ -394,7 +394,7 @@ def test_dynamic_fields(es_store):
     col = getattr(es_store, collection_name)
     col.wipe()
 
-    assert list(sorted(col.fields().keys())) == ['id', 'number']
+    assert list(sorted(col.fields().keys())) == ['id', 'number', 'other']
 
     # Elasticsearch should ignore the type of other
     data = {


### PR DESCRIPTION
This makes odm.Any fields look like unvalidated keywords in the system which fixes their old template nature that was previously only supported by a coincidence but are now broken in ES 7.15