### PR TITLE
Add optional pie attribute for elf32 executables

### DIFF
--- a/assemblyline/common/identify_defaults.py
+++ b/assemblyline/common/identify_defaults.py
@@ -107,7 +107,7 @@ magic_patterns = [
     {"al_type": "executable/windows/com", "regex": r"^com executable"},
     {"al_type": "executable/windows/dos", "regex": r"^8086 relocatable"},
     {"al_type": "executable/windows/coff", "regex": r"^MS Windows COFF"},
-    {"al_type": "executable/linux/elf32", "regex": r"^elf 32-bit (l|m)sb +executable"},
+    {"al_type": "executable/linux/elf32", "regex": r"^elf 32-bit (l|m)sb +(pie )?executable"},
     {"al_type": "executable/linux/elf64", "regex": r"^elf 64-bit (l|m)sb +(pie )?executable"},
     {"al_type": "executable/linux/so32", "regex": r"^elf 32-bit (l|m)sb +shared object"},
     {"al_type": "executable/linux/so64", "regex": r"^elf 64-bit (l|m)sb +shared object"},


### PR DESCRIPTION
File type = "unknown" for https://www.virustotal.com/gui/file/cb1c834ba621dcc4c246f93a072738f2947d9449840d9b166f8acf9723cbb769/details 
=> No dynamic analysis
Using Assemblyline 4.3.0.15
Debian libmagic1/now 1:5.35-4+deb10u2 amd64
Tested manually by modifying regexp in File Identification menu