### PR TITLE
Maco/report update

### DIFF
--- a/assemblyline/odm/models/ontology/ontology.py
+++ b/assemblyline/odm/models/ontology/ontology.py
@@ -5,7 +5,7 @@ from assemblyline.odm.models.ontology.results import Antivirus, Process, Sandbox
 from assemblyline.odm.models.ontology.filetypes import PE
 
 Classification = forge.get_classification()
-ODM_VERSION = "1.1"
+ODM_VERSION = "1.2"
 
 
 @odm.model(description="File Characteristics")

--- a/assemblyline/odm/models/ontology/results/malware_config.py
+++ b/assemblyline/odm/models/ontology/results/malware_config.py
@@ -131,7 +131,7 @@ class Cryptocurrency(odm.Model):
 class Path(odm.Model):
     path = odm.Optional(odm.Text(), description="Path")
     usage = odm.Optional(
-        odm.Enum(values=['c2', 'install', 'plugins', 'logs', 'storage', 'other']),
+        odm.Enum(values=['c2', 'config', 'install', 'plugins', 'logs', 'storage', 'other']),
         description="Use of path")
 
 

--- a/assemblyline/odm/models/ontology/results/malware_config.py
+++ b/assemblyline/odm/models/ontology/results/malware_config.py
@@ -131,7 +131,7 @@ class Cryptocurrency(odm.Model):
 class Path(odm.Model):
     path = odm.Optional(odm.Text(), description="Path")
     usage = odm.Optional(
-        odm.Enum(values=['install', 'plugins', 'logs', 'storage', 'other']),
+        odm.Enum(values=['c2', 'install', 'plugins', 'logs', 'storage', 'other']),
         description="Use of path")
 
 

--- a/assemblyline/odm/models/ontology/results/malware_config.py
+++ b/assemblyline/odm/models/ontology/results/malware_config.py
@@ -145,7 +145,7 @@ class Registry(odm.Model):
 
 
 class MalwareConfig(odm.Model):
-    family = odm.Text(description="What family is this associated to?")
+    family = odm.List(odm.Text(), description="What family is this associated to?")
     version = odm.Optional(odm.Text(), description="Version of the malware")
     category = odm.Optional(odm.List(odm.Enum(values=CATEGORIES)), description="Category of malware")
 

--- a/assemblyline/odm/models/ontology/results/malware_config.py
+++ b/assemblyline/odm/models/ontology/results/malware_config.py
@@ -69,7 +69,7 @@ class HTTP(odm.Model):
     fragment = odm.Optional(odm.Text(), description="Fragment")
     user_agent = odm.Optional(odm.Text(), description="User Agent")
     method = odm.Optional(odm.Enum(values=REQUEST_METHODS), description="Method")
-    header = odm.Optional(odm.Mapping(odm.Text()), description="HTTP Headers")
+    headers = odm.Optional(odm.Mapping(odm.Text()), description="HTTP Headers")
     max_size = odm.Optional(odm.Integer(), description="Maximum size")
     usage = odm.Optional(odm.Enum(values=CONNECTION_USAGE), description="Purpose of HTTP connection")
 


### PR DESCRIPTION
Related to: https://github.com/CybercentreCanada/Maco/pull/13, https://github.com/CybercentreCanada/Maco/pull/10, https://github.com/CybercentreCanada/Maco/pull/17, https://github.com/CybercentreCanada/Maco/pull/14

Modifies the ontology to let `family` accept a list of strings (which involves services to convert output as necessary like https://github.com/CybercentreCanada/assemblyline-service-configextractor/pull/118) and adds 'c2' as an option for path usage.