### PR TITLE
Generalizing the custom magic used for identifying .bat

### DIFF
--- a/assemblyline/common/custom.magic
+++ b/assemblyline/common/custom.magic
@@ -117,7 +117,7 @@
 0 string [InternetShortcut] custom: shortcut/web
 # NSIS Installer
 4  string  \xef\xbe\xad\xdeNullsoftInst custom: archive/nsis
-# Characterize batch file
-0 string REM\ Batch\ extracted\ by\ Characterize\n custom: code/batch
-# Characterize powershell file
+# Assemblyline batch file
+0 string REM\ Batch\ extracted\ by\ Assemblyline\n custom: code/batch
+# Assemblyline powershell file
 0 string \#\!\/usr\/bin\/env\ pwsh\n custom: code/ps1


### PR DESCRIPTION
Partially addresses https://cccs.atlassian.net/browse/AL-2102?focusedCommentId=129006