### PR TITLE
Increase vba priority in identify yara rule

### DIFF
--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -119,6 +119,9 @@ rule code_vbs {
         score = 2
 
     strings:
+        // Avoid false positives like function createObject(param) {, function replace(param) {, etc.
+        $javascript = /function[\w\s(,]+\({/
+
         $strong_vbs1 = /(^|\n)On[ \t]+Error[ \t]+Resume[ \t]+Next/i ascii wide
         $strong_vbs2 = /(^|\n|\()(Private|Public)?[ \t]*(Sub|Function)[ \t]+\w+\([ \t]*((ByVal[ \t]+)?\w+([ \t]+As[ \t]+\w+)?,?)*\)[ \t]*[\)\n]/i ascii wide
         $strong_vbs3 = /(^|\n)[ \t]*End[ \t]+(Module|Function|Sub|If)/i ascii wide
@@ -132,12 +135,13 @@ rule code_vbs {
         $strong_vbs10 = "GetObject(" nocase ascii wide
         $strong_vbs11 = /(^|\n)Eval\(/i ascii wide
         // Dim blah
-        $weak_vbs1 = /\bDim\b\s+\w+/i ascii wide
+        $weak_vbs1 = /\bDim\b\s+\w+[\n:]/i ascii wide
 
     condition:
-        2 of ($strong_vbs*)
-        or (1 of ($strong_vbs*)
-            and (#weak_vbs1) > 3)
+        not $javascript
+        and (2 of ($strong_vbs*)
+            or (1 of ($strong_vbs*)
+            and (#weak_vbs1) > 3))
 }
 
 /*

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -121,7 +121,7 @@ rule code_vbs {
     strings:
         // Avoid false positives like function createObject(param) {, function replace(param) {, etc.
         $javascript = /function[\w\s(,]+\){/
-        $multiline = " = @'\n" //powershell multiline string
+        $multiline = " = @'\r\n" //powershell multiline string
 
         $strong_vbs1 = /(^|\n)On[ \t]+Error[ \t]+Resume[ \t]+Next/i ascii wide
         $strong_vbs2 = /(^|\n|\()(Private|Public)?[ \t]*(Sub|Function)[ \t]+\w+\([ \t]*((ByVal[ \t]+)?\w+([ \t]+As[ \t]+\w+)?,?)*\)[ \t]*[\)\r]/i ascii wide

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -124,7 +124,7 @@ rule code_vbs {
         $strong_vbs5 = /(^|\n)[ \t]*Rem[ \t]+[^\n]+/i ascii wide
         $strong_vbs6 = /(^|\n)(Attribute|Set|const)[ \t]+\w+[ \t]+=[ \t]+[^\n]+/i ascii wide
         $strong_vbs7 = /(^|\n)[ \t]*Err.Raise[ \t]+\d+(,[ \t]+"[^"]+")+/i ascii wide
-        $strong_vbs8 = /replace\(([^,]+,){2}([^)]+)\)/i ascii wide
+        $strong_vbs8 = /[ /t]replace\(/i ascii wide
         // CreateObject("blah")
         $strong_vbs9 = "CreateObject(" nocase ascii wide
         $strong_vbs10 = "GetObject(" nocase ascii wide

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -121,6 +121,7 @@ rule code_vbs {
     strings:
         // Avoid false positives like function createObject(param) {, function replace(param) {, etc.
         $javascript = /function[\w\s(,]+\){/
+        $multiline = " = @'\n" //powershell multiline string
 
         $strong_vbs1 = /(^|\n)On[ \t]+Error[ \t]+Resume[ \t]+Next/i ascii wide
         $strong_vbs2 = /(^|\n|\()(Private|Public)?[ \t]*(Sub|Function)[ \t]+\w+\([ \t]*((ByVal[ \t]+)?\w+([ \t]+As[ \t]+\w+)?,?)*\)[ \t]*[\)\n]/i ascii wide
@@ -138,7 +139,7 @@ rule code_vbs {
         $weak_vbs1 = /\bDim\b\s+\w+[\n:]/i ascii wide
 
     condition:
-        not $javascript
+        not $javascript and not $multiline
         and (2 of ($strong_vbs*)
             or (1 of ($strong_vbs*)
             and (#weak_vbs1) > 3))

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -124,19 +124,20 @@ rule code_vbs {
         $multiline = " = @'\n" //powershell multiline string
 
         $strong_vbs1 = /(^|\n)On[ \t]+Error[ \t]+Resume[ \t]+Next/i ascii wide
-        $strong_vbs2 = /(^|\n|\()(Private|Public)?[ \t]*(Sub|Function)[ \t]+\w+\([ \t]*((ByVal[ \t]+)?\w+([ \t]+As[ \t]+\w+)?,?)*\)[ \t]*[\)\n]/i ascii wide
+        $strong_vbs2 = /(^|\n|\()(Private|Public)?[ \t]*(Sub|Function)[ \t]+\w+\([ \t]*((ByVal[ \t]+)?\w+([ \t]+As[ \t]+\w+)?,?)*\)[ \t]*[\)\r]/i ascii wide
         $strong_vbs3 = /(^|\n)[ \t]*End[ \t]+(Module|Function|Sub|If)/i ascii wide
         $strong_vbs4 = /(^|\n)ExecuteGlobal/ ascii wide
         $strong_vbs5 = /(^|\n)[ \t]*Rem[ \t]+[^\n]+/i ascii wide
-        $strong_vbs6 = /(^|\n)(Attribute|Set|const)[ \t]+\w+[ \t]+=[ \t]+[^\n]+/i ascii wide
+        $strong_vbs6 = /(^|\n|:)(Attribute|Set|const)[ \t]+\w+[ \t]*=/i ascii wide
         $strong_vbs7 = /(^|\n)[ \t]*Err.Raise[ \t]+\d+(,[ \t]+"[^"]+")+/i ascii wide
-        $strong_vbs8 = /[ \t]replace\(/i ascii wide
+        $strong_vbs8 = /[ \t(=]replace\(/i ascii wide
         // CreateObject("blah")
         $strong_vbs9 = "CreateObject(" nocase ascii wide
         $strong_vbs10 = "GetObject(" nocase ascii wide
         $strong_vbs11 = /(^|\n)Eval\(/i ascii wide
+        $string_vbs12 = "Execute(" nocase ascii wide
         // Dim blah
-        $weak_vbs1 = /\bDim\b\s+\w+[\n:]/i ascii wide
+        $weak_vbs1 = /\bDim\b\s+\w+[\r:]/i ascii wide
 
     condition:
         not $javascript and not $multiline

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -126,9 +126,9 @@ rule code_vbs {
         $strong_vbs7 = /(^|\n)[ \t]*Err.Raise[ \t]+\d+(,[ \t]+"[^"]+")+/i ascii wide
         $strong_vbs8 = /replace\(([^,]+,){2}([^)]+)\)/i ascii wide
         // CreateObject("blah")
-        $strong_vbs9 = /CreateObject\([^)]+\)/i ascii wide
-        $strong_vbs10 = /GetObject\([^)]+\)/i ascii wide
-        $strong_vbs11 = /(^|\n)Eval\(([^)]+)\)/i ascii wide
+        $strong_vbs9 = "CreateObject(" nocase ascii wide
+        $strong_vbs10 = "GetObject(" nocase ascii wide
+        $strong_vbs11 = /(^|\n)Eval\(/i ascii wide
         // Dim blah
         $weak_vbs1 = /\bDim\b\s+\w+/i ascii wide
 

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -124,7 +124,7 @@ rule code_vbs {
         $strong_vbs5 = /(^|\n)[ \t]*Rem[ \t]+[^\n]+/i ascii wide
         $strong_vbs6 = /(^|\n)(Attribute|Set|const)[ \t]+\w+[ \t]+=[ \t]+[^\n]+/i ascii wide
         $strong_vbs7 = /(^|\n)[ \t]*Err.Raise[ \t]+\d+(,[ \t]+"[^"]+")+/i ascii wide
-        $strong_vbs8 = /[ /t]replace\(/i ascii wide
+        $strong_vbs8 = /[ \t]replace\(/i ascii wide
         // CreateObject("blah")
         $strong_vbs9 = "CreateObject(" nocase ascii wide
         $strong_vbs10 = "GetObject(" nocase ascii wide

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -128,7 +128,7 @@ rule code_vbs {
         $strong_vbs3 = /(^|\n)[ \t]*End[ \t]+(Module|Function|Sub|If)/i ascii wide
         $strong_vbs4 = /(^|\n)ExecuteGlobal/ ascii wide
         $strong_vbs5 = /(^|\n)[ \t]*Rem[ \t]+[^\n]+/i ascii wide
-        $strong_vbs6 = /(^|\n|:)(Attribute|Set|const)[ \t]+\w+[ \t]*=/i ascii wide
+        $strong_vbs6 = /(^|\n|:)(Attribute|Set|const)[ \t]+\w+[ \t]+=/i ascii wide
         $strong_vbs7 = /(^|\n)[ \t]*Err.Raise[ \t]+\d+(,[ \t]+"[^"]+")+/i ascii wide
         $strong_vbs8 = /[ \t(=]replace\(/i ascii wide
         // CreateObject("blah")

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -127,7 +127,6 @@ rule code_vbs {
         $strong_vbs2 = /(^|\n|\()(Private|Public)?[ \t]*(Sub|Function)[ \t]+\w+\([ \t]*((ByVal[ \t]+)?\w+([ \t]+As[ \t]+\w+)?,?)*\)[ \t]*[\)\r]/i ascii wide
         $strong_vbs3 = /(^|\n)[ \t]*End[ \t]+(Module|Function|Sub|If)/i ascii wide
         $strong_vbs4 = /(^|\n)ExecuteGlobal/ ascii wide
-        $strong_vbs5 = /(^|\n)[ \t]*Rem[ \t]+[^\n]+/i ascii wide
         $strong_vbs6 = /(^|\n|:)(Attribute|Set|const)[ \t]+\w+[ \t]+=/i ascii wide
         $strong_vbs7 = /(^|\n)[ \t]*Err.Raise[ \t]+\d+(,[ \t]+"[^"]+")+/i ascii wide
         $strong_vbs8 = /[ \t(=]replace\(/i ascii wide

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -119,8 +119,6 @@ rule code_vbs {
         score = 2
 
     strings:
-        // Avoid false positives like function createObject(param) {, function replace(param) {, etc.
-        $javascript = /function[\w\s(,]+\){/
         $multiline = " = @'\r\n" //powershell multiline string
 
         $strong_vbs1 = /(^|\n)On[ \t]+Error[ \t]+Resume[ \t]+Next/i ascii wide
@@ -139,7 +137,7 @@ rule code_vbs {
         $weak_vbs1 = /\bDim\b\s+\w+[\r:]/i ascii wide
 
     condition:
-        not $javascript and not $multiline
+        not code_javascript and not $multiline
         and (2 of ($strong_vbs*)
             or (1 of ($strong_vbs*)
             and (#weak_vbs1) > 3))

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -135,7 +135,7 @@ rule code_vbs {
         $strong_vbs9 = "CreateObject(" nocase ascii wide
         $strong_vbs10 = "GetObject(" nocase ascii wide
         $strong_vbs11 = /(^|\n)Eval\(/i ascii wide
-        $string_vbs12 = "Execute(" nocase ascii wide
+        $strong_vbs12 = "Execute(" nocase ascii wide
         // Dim blah
         $weak_vbs1 = /\bDim\b\s+\w+[\r:]/i ascii wide
 

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -73,7 +73,9 @@ rule code_jscript {
         score = 5
 
     strings:
-        $jscript1 = /new[ \t]+ActiveXObject\(/
+        $jscript1 = "ActiveXObject" fullword
+        $jscript2 = "= GetObject("
+        $jscript3 = "WScript.CreateObject("
 
         // Conditional comments
         $jscript2 = /\/\*@cc_on/

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -78,10 +78,10 @@ rule code_jscript {
         $jscript3 = "WScript.CreateObject("
 
         // Conditional comments
-        $jscript2 = /\/\*@cc_on/
-        $jscript3 = /@\*\//
-        $jscript4 = /\/\*@if \(@_jscript_version >= \d\)/
-        $jscript5 = /\/\*@end/
+        $jscript4 = /\/\*@cc_on/
+        $jscript5 = /@\*\//
+        $jscript6 = /\/\*@if \(@_jscript_version >= \d\)/
+        $jscript7 = /\/\*@end/
 
     condition:
         code_javascript

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -120,7 +120,7 @@ rule code_vbs {
 
     strings:
         // Avoid false positives like function createObject(param) {, function replace(param) {, etc.
-        $javascript = /function[\w\s(,]+\({/
+        $javascript = /function[\w\s(,]+\){/
 
         $strong_vbs1 = /(^|\n)On[ \t]+Error[ \t]+Resume[ \t]+Next/i ascii wide
         $strong_vbs2 = /(^|\n|\()(Private|Public)?[ \t]*(Sub|Function)[ \t]+\w+\([ \t]*((ByVal[ \t]+)?\w+([ \t]+As[ \t]+\w+)?,?)*\)[ \t]*[\)\n]/i ascii wide

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -114,6 +114,7 @@ rule code_vbs {
 
     meta:
         type = "code/vbs"
+        score = 2
 
     strings:
         $strong_vbs1 = /(^|\n)On[ \t]+Error[ \t]+Resume[ \t]+Next/i ascii wide


### PR DESCRIPTION
Raising priority of VBA above that of powershell to prevent VBA containing powershell from identifying as code/ps1