### PR TITLE
Detect multipart MIME format as eml

### DIFF
--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -337,9 +337,9 @@ rule document_email_2 {
         score = 10
 
     strings:
+        $ = /(^|\n)From: /
         $ = /(^|\n)MIME-Version: /
-        $ = /(^|\n)Content-Type: /
-        $ = "This is a multipart message in MIME format."
+        $ = /(^|\n)Content-Type: multipart\/mixed;\s*boundary=/
 
     condition:
         all of them


### PR DESCRIPTION
Based on the format found at https://learn.microsoft.com/en-us/previous-versions/office/developer/exchange-server-2010/aa563375(v=exchg.140)