### PR TITLE
Add identification for emails in HTML format

### DIFF
--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -356,6 +356,31 @@ rule document_email_2 {
 }
 
 /*
+document/html/email
+*/
+
+rule document_html_email_1 {
+
+    meta:
+        type = "document/html/email"
+        score = 15
+    strings:
+        $rec = "From:"
+        $subrec1 = "Bcc:"
+        $subrec2 = "To:"
+        $opt1 = "Subject:"
+        $opt2 = "Received:"
+        $opt3 = "MIME-Version:"
+        $opt4 = "Content-Type:"
+
+    condition:
+        (code_html_1 or code_html_2 or code_html_3)
+        and all of ($rec*)
+        and 1 of ($subrec*)
+        and 1 of ($opt*)
+}
+
+/*
 log/vipermonkey
 */
 

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -325,14 +325,14 @@ rule document_email_1 {
         score = 15
 
     strings:
-        $rec = "From: "
-        $rec2 = "Date: "
-        $subrec1 = "Bcc: "
-        $subrec2 = "To: "
-        $opt1 = "Subject: "
+        $rec = "From:"
+        $subrec1 = "Bcc:"
+        $subrec2 = "To:"
+        $subrec3 = "Date:"
+        $opt1 = "Subject:"
         $opt2 = "Received: from"
-        $opt3 = "MIME-Version: "
-        $opt4 = "Content-Type: "
+        $opt3 = "MIME-Version:"
+        $opt4 = "Content-Type:"
 
     condition:
         all of ($rec*)
@@ -355,30 +355,6 @@ rule document_email_2 {
         all of them
 }
 
-/*
-document/html/email
-*/
-
-rule document_html_email_1 {
-
-    meta:
-        type = "document/html/email"
-        score = 15
-    strings:
-        $rec = "From:"
-        $subrec1 = "Bcc:"
-        $subrec2 = "To:"
-        $opt1 = "Subject:"
-        $opt2 = "Received:"
-        $opt3 = "MIME-Version:"
-        $opt4 = "Content-Type:"
-
-    condition:
-        (code_html_1 or code_html_2 or code_html_3)
-        and all of ($rec*)
-        and 1 of ($subrec*)
-        and 1 of ($opt*)
-}
 
 /*
 log/vipermonkey


### PR DESCRIPTION
Will be used by Frankenstrings (reject) and EmlParser (accept) to distinguish the difference between plain HTML and HTML formatted to represent an email.