### PR TITLE
Fix result elastic entry id building

### DIFF
--- a/assemblyline/odm/models/result.py
+++ b/assemblyline/odm/models/result.py
@@ -137,7 +137,7 @@ class Result(odm.Model):
         key_list = [
             sha256,
             service_name.replace('.', '_'),
-            f"v{service_version.replace('.', '_')}",
+            f"v{service_version.replace('.', '_').replace('stable', '')}",
             f"c{generate_conf_key(service_tool_version=service_tool_version, task=task)}",
         ]
 


### PR DESCRIPTION
Hi guys,

I still have a bug with the cache. In my tests, I have no real usage of result cache. Each time a new result will be produce and overwrite the previous one.

## bug

The orchestrator use a different id for getting the result from cache then putting the new result.
`Characterize.v4_4_0_stable14.c194ZBEYk2` the first time then `Characterize.v4_4_0_.14c194ZBEYk2`

## suggestion

Add the removing of `stable` directly in the `Result.help_build_key` function, to ensure that we always have the same id

in tasking_client.py
```python
 service.version = service.version.replace('stable', '')
...
# in get_task
result_key = Result.help_build_key(sha256=task.fileinfo.sha256,
                                           service_name=service_name,
                                           service_version=service_version,
                                           service_tool_version=service_tool_version,
                                           is_empty=False,
                                           task=task)

# in handle result
result_key = result.build_key(service_tool_version=result.response.service_tool_version, task=task)
```

the second time the `stable` part is here.

```python
# build_key code:
def build_key(self, service_tool_version=None, task=None):
        return self.help_build_key(
            self.sha256,
            self.response.service_name,
            self.response.service_version,
            self.is_empty(),
            service_tool_version=service_tool_version,
            task=task
```

## Investigation

To pinpoint the error, I've done some network captures.

The communication between service and service server
```
GET /api/v1/task/ HTTP/1.1
Host: service-server:5003
service_name: Characterize
service_version: 4.4.0.stable14
timeout: 30

GET /api/v1/file/004331f3855ee6a3bcd22e7b956251397571025ecb9d170c762988c3fc0ec7fb/ HTTP/1.1
Host: service-server:5003
service_name: Characterize
service_version: 4.4.0.stable14
timeout: 30


POST /api/v1/task/ HTTP/1.1
Host: service-server:5003
service_name: Characterize
service_version: 4.4.0.stable14
timeout: 30

GET /api/v1/task/ HTTP/1.1
Host: service-server:5003
service_name: Characterize
service_version: 4.4.0.stable14
timeout: 30


GET /api/v1/file/004331f3855ee6a3bcd22e7b956251397571025ecb9d170c762988c3fc0ec7fb/ HTTP/1.1
Host: service-server:5003
service_name: Characterize
service_version: 4.4.0.stable14
timeout: 30


POST /api/v1/task/ HTTP/1.1
Host: service-server:5003
service_name: Characterize
service_version: 4.4.0.stable14
timeout: 30
```

The same capture on the elastic interface

```

GET /result/_doc/004331f3855ee6a3bcd22e7b956251397571025ecb9d170c762988c3fc0ec7fb.Characterize.v4_4_0_stable14.c194ZBEYk2AF HTTP/1.1
Host: elasticsearch:9200

HTTP/1.1 404 Not Found



GET /emptyresult/_doc/004331f3855ee6a3bcd22e7b956251397571025ecb9d170c762988c3fc0ec7fb.Characterize.v4_4_0_stable14.c194ZBEYk2AF.e HTTP/1.1
Host: elasticsearch:9200

HTTP/1.1 404 Not Found


PUT /result/_doc/004331f3855ee6a3bcd22e7b956251397571025ecb9d170c762988c3fc0ec7fb.Characterize.v4_4_0_14.c194ZBEYk2AF?if_primary_term=1&if_seq_no=11&op_type=index HTTP/1.1
Host: elasticsearch:9200
{...
"milestones": {
  "service_started": "2023-10-17T10:00:48.636715Z",
  "service_completed": "2023-10-17T10:00:48.737719Z"
},
...}

HTTP/1.1 200 OK



GET /result/_doc/004331f3855ee6a3bcd22e7b956251397571025ecb9d170c762988c3fc0ec7fb.Characterize.v4_4_0_stable14.c194ZBEYk2AF HTTP/1.1
Host: elasticsearch:9200

HTTP/1.1 404 Not Found


GET /emptyresult/_doc/004331f3855ee6a3bcd22e7b956251397571025ecb9d170c762988c3fc0ec7fb.Characterize.v4_4_0_stable14.c194ZBEYk2AF.e HTTP/1.1
Host: elasticsearch:9200


HTTP/1.1 404 Not Found


PUT /result/_doc/004331f3855ee6a3bcd22e7b956251397571025ecb9d170c762988c3fc0ec7fb.Characterize.v4_4_0_14.c194ZBEYk2AF?if_primary_term=1&if_seq_no=12&op_type=index HTTP/1.1
Host: elasticsearch:9200

{...
"milestones": {
  "service_started": "2023-10-17T10:03:24.437794Z", 
  "service_completed": "2023-10-17T10:03:24.542633Z"
}, 
...}

HTTP/1.1 200 OK
```

In the capture, we can see that the orchestrator use a different id for getting the result from cache then putting the new result.
`Characterize.v4_4_0_stable14.c194ZBEYk2` the first time then `Characterize.v4_4_0_.c194ZBEYk2`