### PR TITLE
Removing resource/unity identification

### DIFF
--- a/assemblyline/common/custom.magic
+++ b/assemblyline/common/custom.magic
@@ -88,8 +88,6 @@
 0   string  PTCH\007\001  custom: resource/ptc
 0       string  SBle
 >16     string  MRAH     custom: resource/sbr
-0   string
->&0     regex/40        [0-9]\\.[0-9]\\.[0-9][a-zA-Z][0-9]     custom: resource/unity
 # Database files
 # DBF
 0   string  DBPF\002\000\000\000\001    custom: db/dbf


### PR DESCRIPTION
This line was part of a group that was used to filter out files in android APK. As CybercentreCanada/assemblyline/issues/138 is pointing out, this is causing normal gzip files to be mis-identified.