### PR TITLE
Split the different functions to be distinct for the count

### DIFF
--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -546,24 +546,65 @@ rule code_ps1 {
     strings:
         // Supported by https://github.com/CERT-Polska/karton-classifier/blob/4cf125296e3a0c1d6c1cb8c16f97d608054c7f19/karton/classifier/classifier.py#L671
         // Supported and inspired by https://github.com/CAPESandbox/sflock/blob/1e0ed7e18ddfe723c2d2603875ca26d63887c189/sflock/ident.py#L406
-        $strong_pwsh1 = /(IWR|Add-(MpPreference|Type)|Start-(BitsTransfer|Sleep|Process)|Get-(ExecutionPolicy|Service|Process|Counter|WinEvent|ChildItem|Variable|Item|WmiObject)|Where-Object|ConvertTo-HTML|Select-Object|Clear-(History|Content)|ForEach-Object|Compare-Object|New-(ItemProperty|Object|WebServiceProxy)|Set-(Alias|Location|Item|ItemProperty|StringMode)|Wait-Job|Test-Path|Rename-Item|Stop-Process|Out-String|Write-Error|Invoke-(Expression|WebRequest)|Copy-Item|Import-Module)\b/i ascii wide
-        $strong_pwsh2 = /(-ExclusionPath|-memberDefinition|-Name|-namespace|-passthru|-command|-TypeName|-join|-split|-sou|-dest|-property|-OutF(ile)?|-ExecutionPolicy Bypass|-uri|-AllowStartIfOnBatteries|-MultipleInstances|-TaskName|-Trigger)\b/i ascii wide
+        $strong_pwsh1 = "IWR" nocase ascii wide fullword
+        $strong_pwsh2 = "Add-MpPreference" nocase ascii wide fullword
+        $strong_pwsh3 = "Add-Type" nocase ascii wide fullword
+        $strong_pwsh4 = "Start-BitsTransfer" nocase ascii wide fullword
+        $strong_pwsh5 = "Start-Sleep" nocase ascii wide fullword
+        $strong_pwsh6 = "Start-Process" nocase ascii wide fullword
+        $strong_pwsh7 = "Get-ExecutionPolicy" nocase ascii wide fullword
+        $strong_pwsh8 = "Get-Service" nocase ascii wide fullword
+        $strong_pwsh9 = "Get-Process" nocase ascii wide fullword
+        $strong_pwsh10 = "Get-Counter" nocase ascii wide fullword
+        $strong_pwsh11 = "Get-WinEvent" nocase ascii wide fullword
+        $strong_pwsh12 = "Get-ChildItem" nocase ascii wide fullword
+        $strong_pwsh13 = "Get-Variable" nocase ascii wide fullword
+        $strong_pwsh14 = "Get-Item" nocase ascii wide fullword
+        $strong_pwsh15 = "Get-WmiObject" nocase ascii wide fullword
+        $strong_pwsh16 = "Where-Object" nocase ascii wide fullword
+        $strong_pwsh17 = "ConvertTo-HTML" nocase ascii wide fullword
+        $strong_pwsh18 = "Select-Object" nocase ascii wide fullword
+        $strong_pwsh19 = "Clear-History" nocase ascii wide fullword
+        $strong_pwsh20 = "Clear-Content" nocase ascii wide fullword
+        $strong_pwsh21 = "ForEach-Object" nocase ascii wide fullword
+        $strong_pwsh22 = "Compare-Object" nocase ascii wide fullword
+        $strong_pwsh23 = "New-ItemProperty" nocase ascii wide fullword
+        $strong_pwsh24 = "New-Object" nocase ascii wide fullword
+        $strong_pwsh25 = "New-WebServiceProxy" nocase ascii wide fullword
+        $strong_pwsh26 = "Set-Alias" nocase ascii wide fullword
+        $strong_pwsh27 = "Set-Location" nocase ascii wide fullword
+        $strong_pwsh28 = "Set-Item" nocase ascii wide fullword
+        $strong_pwsh29 = "Set-ItemProperty" nocase ascii wide fullword
+        $strong_pwsh30 = "Set-StringMode" nocase ascii wide fullword
+        $strong_pwsh31 = "Wait-Job" nocase ascii wide fullword
+        $strong_pwsh32 = "Test-Path" nocase ascii wide fullword
+        $strong_pwsh33 = "Rename-Item" nocase ascii wide fullword
+        $strong_pwsh34 = "Stop-Process" nocase ascii wide fullword
+        $strong_pwsh35 = "Out-String" nocase ascii wide fullword
+        $strong_pwsh36 = "Write-Error" nocase ascii wide fullword
+        $strong_pwsh37 = "Invoke-Expression" nocase ascii wide fullword
+        $strong_pwsh38 = "Invoke-WebRequest" nocase ascii wide fullword
+        $strong_pwsh39 = "Copy-Item" nocase ascii wide fullword
+        $strong_pwsh40 = "Import-Module" nocase ascii wide fullword
+        $strong_pwsh41 = "Expand-Archive" nocase ascii wide fullword
+
+        $strong_pwsh100 = /(-ExclusionPath|-memberDefinition|-Name|-namespace|-passthru|-command|-TypeName|-join|-split|-sou|-dest|-property|-OutF(ile)?|-ExecutionPolicy Bypass|-uri|-AllowStartIfOnBatteries|-MultipleInstances|-TaskName|-Trigger)\b/i ascii wide
         // Supported by https://github.com/CERT-Polska/karton-classifier/blob/4cf125296e3a0c1d6c1cb8c16f97d608054c7f19/karton/classifier/classifier.py#L671
-        $strong_pwsh3 = /(\.Get(String|Field|Type|Method)|FromBase64String)\(/i ascii wide
-        $strong_pwsh4 = "System.Net.WebClient" nocase ascii wide
-        $strong_pwsh5 = "Net.ServicePointManager" nocase ascii wide
-        $strong_pwsh6 = "Net.SecurityProtocolType" nocase ascii wide
-        $strong_pwsh7 = /\[(System\.)?Text\.Encoding\]::UTF8/i ascii wide
-        $strong_pwsh8 = /\[(System\.)?Convert\]::ToInt32/i ascii wide
-        $strong_pwsh9 = /\[(System\.)?String]::Join\(/i ascii wide
-        $strong_pwsh10 = /\[byte\[\]\][ \t]*\$\w+[ \t]*=/i ascii wide
-        $strong_pwsh11 = /\[Microsoft\.VisualBasic\.(Interaction|CallType)\]/i ascii wide
-        $strong_pwsh12 = /[ \t;\n]foreach[ \t]*\([ \t]*\$\w+[ \t]+in[ \t]+[^)]+\)[ \t;\n]*{/i ascii wide
-        $strong_pwsh13 = /\[char\][ \t]*(\d\d|0x[0-9a-f]{1,2})/i ascii wide
+        $strong_pwsh101 = /(\.Get(String|Field|Type|Method)|FromBase64String)\(/i ascii wide
+        $strong_pwsh102 = "System.Net.WebClient" nocase ascii wide
+        $strong_pwsh103 = "Net.ServicePointManager" nocase ascii wide
+        $strong_pwsh104 = "Net.SecurityProtocolType" nocase ascii wide
+        $strong_pwsh105 = /\[(System\.)?Text\.Encoding\]::UTF8/i ascii wide
+        $strong_pwsh106 = /\[(System\.)?Convert\]::ToInt32/i ascii wide
+        $strong_pwsh107 = /\[(System\.)?String]::Join\(/i ascii wide
+        $strong_pwsh108 = /\[byte\[\]\][ \t]*\$\w+[ \t]*=/i ascii wide
+        $strong_pwsh109 = /\[Microsoft\.VisualBasic\.(Interaction|CallType)\]/i ascii wide
+        $strong_pwsh110 = /[ \t;\n]foreach[ \t]*\([ \t]*\$\w+[ \t]+in[ \t]+[^)]+\)[ \t;\n]*{/i ascii wide
+        $strong_pwsh111 = /\[char\][ \t]*(\d\d|0x[0-9a-f]{1,2})/i ascii wide
         // Inspired by https://github.com/CERT-Polska/karton-classifier/blob/4cf125296e3a0c1d6c1cb8c16f97d608054c7f19/karton/classifier/classifier.py#L671
-        $strong_pwsh14 = /\|[ \t]*iex\b/i ascii wide
+        $strong_pwsh112 = /\|[ \t]*iex\b/i ascii wide
         // Inspired by https://github.com/CAPESandbox/sflock/blob/1e0ed7e18ddfe723c2d2603875ca26d63887c189/sflock/ident.py#L406
-        $strong_pwsh15 = "$PSHOME" nocase ascii wide
+        $strong_pwsh113 = "$PSHOME" nocase ascii wide
         $weak_pwsh1 = /\$\w+[ \t]*=[ \t]*[^;\n|]+[;\n|]/ ascii wide
 
         // https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.3
@@ -607,7 +648,7 @@ rule code_ps1_first_line {
         score = 5
 
     strings:
-        $strong_pwsh = /^[^\n]*(IWR|Add-(MpPreference|Type)|Start-(BitsTransfer|Sleep|Process)|Get-(ExecutionPolicy|Service|Process|Counter|WinEvent|ChildItem|Variable|Item|WmiObject)|Where-Object|ConvertTo-HTML|Select-Object|Clear-(History|Content)|ForEach-Object|Compare-Object|New-(ItemProperty|Object|WebServiceProxy)|Set-(Alias|Location|Item|ItemProperty|StringMode)|Wait-Job|Test-Path|Rename-Item|Stop-Process|Out-String|Write-Error|Invoke-(Expression|WebRequest)|Copy-Item|Import-Module)\b/i ascii wide
+        $strong_pwsh = /^[^\n]*(IWR|Add-(MpPreference|Type)|Start-(BitsTransfer|Sleep|Process)|Get-(ExecutionPolicy|Service|Process|Counter|WinEvent|ChildItem|Variable|Item|WmiObject)|Where-Object|ConvertTo-HTML|Select-Object|Clear-(History|Content)|ForEach-Object|Compare-Object|New-(ItemProperty|Object|WebServiceProxy)|Set-(Alias|Location|Item|ItemProperty|StringMode)|Wait-Job|Test-Path|Rename-Item|Stop-Process|Out-String|Write-Error|Invoke-(Expression|WebRequest)|Copy-Item|Import-Module|Expand-Archive)\b/i ascii wide
         $powershell = /^[^\n]*\^?p(\^|%[^%\n]{0,100}%)?o(\^|%[^%\n]{0,100}%)?w(\^|%[^%\n]{0,100}%)?e(\^|%[^%\n]{0,100}%)?r(\^|%[^%\n]{0,100}%)?s(\^|%[^%\n]{0,100}%)?h(\^|%[^%\n]{0,100}%)?e(\^|%[^%\n]{0,100}%)?l(\^|%[^%\n]{0,100}%)?l(\^|%[^%\n]{0,100}%)?(\.(\^|%[^%\n]{0,100}%)?e(\^|%[^%\n]{0,100}%)?x(\^|%[^%\n]{0,100}%)?e(\^|%[^%\n]{0,100}%)?)?\b/i
 
     condition:


### PR DESCRIPTION
48722fa5b4613e2f7a0c9535c9d1401cdfde731bb51c78219a199600aa2f0a3c is not identified as code/ps1, but it's so simple FrankenStrings is able to get the base64 blob out of it. That base64 blob with a hash of 47aec6ffd224d4825121c20f22d83870127fc241ad958e849cbf54af638fdc26 is identified as "unknown" unless we count those functions independently, this is the file that is targeted by this pull request.
I think we can split the functions like so, and not count the total amount of function because I wouldn't want to count a script having a Get-WmiObject with a Start-Process and a Invoke-WebRequest the same as a script having three IWR. A three letter string can be found many times in files and become a false positive.