### PR TITLE
Improve ps1 script identification

### DIFF
--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -600,6 +600,24 @@ rule code_ps1 {
         )
 }
 
+rule code_ps1_first_line {
+
+    meta:
+        type = "code/ps1"
+        score = 5
+
+    strings:
+        $strong_pwsh = /^[^\n]*(IWR|Add-(MpPreference|Type)|Start-(BitsTransfer|Sleep|Process)|Get-(ExecutionPolicy|Service|Process|Counter|WinEvent|ChildItem|Variable|Item|WmiObject)|Where-Object|ConvertTo-HTML|Select-Object|Clear-(History|Content)|ForEach-Object|Compare-Object|New-(ItemProperty|Object|WebServiceProxy)|Set-(Alias|Location|Item|ItemProperty|StringMode)|Wait-Job|Test-Path|Rename-Item|Stop-Process|Out-String|Write-Error|Invoke-(Expression|WebRequest)|Copy-Item|Import-Module)\b/i ascii wide
+        $powershell = /^[^\n]*\^?p(\^|%[^%\n]{0,100}%)?o(\^|%[^%\n]{0,100}%)?w(\^|%[^%\n]{0,100}%)?e(\^|%[^%\n]{0,100}%)?r(\^|%[^%\n]{0,100}%)?s(\^|%[^%\n]{0,100}%)?h(\^|%[^%\n]{0,100}%)?e(\^|%[^%\n]{0,100}%)?l(\^|%[^%\n]{0,100}%)?l(\^|%[^%\n]{0,100}%)?(\.(\^|%[^%\n]{0,100}%)?e(\^|%[^%\n]{0,100}%)?x(\^|%[^%\n]{0,100}%)?e(\^|%[^%\n]{0,100}%)?)?\b/i
+
+    condition:
+        code_ps1
+        and (
+            @strong_pwsh[1] < @powershell[1]
+            or ($strong_pwsh and not $powershell)
+        )
+}
+
 rule code_ps1_in_ps1 {
 
     meta:


### PR DESCRIPTION
Needed to identify 161078c53263fc1893f38b94e6c11441b61a120031f553d25d90cac7ecdb1ae6 as code/ps1 instead of code/batch

48722fa5b4613e2f7a0c9535c9d1401cdfde731bb51c78219a199600aa2f0a3c is not identified as code/ps1, but it's so simple FrankenStrings is able to get the base64 blob out of it. That base64 blob with a hash of 47aec6ffd224d4825121c20f22d83870127fc241ad958e849cbf54af638fdc26 is identified as "unknown" unless we count those functions independently, this is the file that is targeted by this pull request.
I think we can split the functions like so, and not count the total amount of function because I wouldn't want to count a script having a Get-WmiObject with a Start-Process and a Invoke-WebRequest the same as a script having three IWR. A three letter string can be found many times in files and become a false positive.