### PR TITLE
Enable group lookups using uid instead of dn

### DIFF
--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -108,6 +108,7 @@ class LDAP(odm.Model):
     classification_mappings: Dict[str, str] = odm.Any(description="Classification mapping")
     email_field: str = odm.Keyword(description="Name of the field containing the email address")
     group_lookup_query: str = odm.Keyword(description="How the group lookup is queried")
+    group_lookup_with_uid: bool = odm.Boolean(description="Use username/uid instead of dn for group lookup")
     image_field: str = odm.Keyword(description="Name of the field containing the user's avatar")
     image_format: str = odm.Keyword(description="Type of image used to store the avatar")
     name_field: str = odm.Keyword(description="Name of the field containing the user's name")
@@ -131,6 +132,7 @@ DEFAULT_LDAP = {
     "base": "ou=people,dc=assemblyline,dc=local",
     "email_field": "mail",
     "group_lookup_query": "(&(objectClass=Group)(member=%s))",
+    "group_lookup_with_uid": False,
     "image_field": "jpegPhoto",
     "image_format": "jpeg",
     "name_field": "cn",


### PR DESCRIPTION
This is in preparation for another PR which will be opened against assemblyline_ui.

Our LDAP structure uses memberUid instead of member on LDAP group objects, so the member uid is stored instead of the member dn. Therefore we would like to see this supported by AssemblyLine.

Is there any other area besides assemblyline_ui that would need to updated?