### PR TITLE
Cleanup references to 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
 # won't fail if dist isn't there. The dist* copies in any dist directory only if it exists.)
 COPY setup.py dist* dist/
 RUN pip install --no-cache-dir --no-warn-script-location -f dist/ --user assemblyline==$version && rm -rf ~/.cache/pip
-RUN chmod 750 /root/.local/lib/python3.9/site-packages
+RUN chmod 750 /root/.local/lib/python3.11/site-packages
 
 FROM base
 
@@ -52,7 +52,7 @@ RUN chown assemblyline:assemblyline /var/log/assemblyline
 # Install assemblyline base
 COPY --chown=assemblyline:assemblyline --from=builder /root/.local /var/lib/assemblyline/.local
 ENV PATH=/var/lib/assemblyline/.local/bin:$PATH
-ENV PYTHONPATH=/var/lib/assemblyline/.local/lib/python3.9/site-packages
+ENV PYTHONPATH=/var/lib/assemblyline/.local/lib/python3.11/site-packages
 ENV ASSEMBLYLINE_VERSION=${version}
 ENV ASSEMBLYLINE_IMAGE_TAG=${version_tag}
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is Assemblyline 4 base repository. It provides Assemblyline with common lib
 
 #### System requirements
 
-Assemblyline 4 will only work on systems running python3.9 and was only tested on linux systems.
+Assemblyline 4 will only work on systems running python3.11 and was only tested on linux systems.
 
 #### Installation requirements
 
@@ -19,7 +19,7 @@ If used outside of our normal container this library requires outside linux libr
 - libffi8 (dev)
 - libfuxxy2 (dev)
 - libmagic1
-- python3.9 (dev)
+- python3.11 (dev)
 
 Here is an example on how you would get those libraries on a `Ubuntu 20.04+` system:
 

--- a/incremental.Dockerfile
+++ b/incremental.Dockerfile
@@ -18,7 +18,7 @@ ARG version_tag=${version}
 # Install assemblyline base
 COPY --chown=assemblyline:assemblyline --from=builder /root/.local /var/lib/assemblyline/.local
 ENV PATH=/var/lib/assemblyline/.local/bin:$PATH
-ENV PYTHONPATH=/var/lib/assemblyline/.local/lib/python3.9/site-packages
+ENV PYTHONPATH=/var/lib/assemblyline/.local/lib/python3.11/site-packages
 ENV ASSEMBLYLINE_VERSION=${version}
 ENV ASSEMBLYLINE_IMAGE_TAG=${version_tag}
 


### PR DESCRIPTION
Will fix user switching for components like Vacuum