### PR TITLE
Identify Mobi ebook

### DIFF
--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -910,7 +910,7 @@ rule code_batch {
         $cmd7 = /(^|\n|@|&)timeout[ \t](\/\w+|[-]?\d{1,5})/i
         $rem1 = /(^|\n|@|&)\^?r\^?e\^?m\^?[ \t]\w+/i
         $rem2 = /(^|\n)::/
-        $set = /(^|\n|@|&)\^?s\^?e\^?t\^?[ \t]\^?\w+\^?=\^?\w+/i
+        $set = /(^|\n|@|&)\^?s\^?e\^?t\^?[ \t]\^?\w+\^?=\^?%?\^?\w+/i
         $exp = /setlocal[ \t](enableDelayedExpansion|disableDelayedExpansion)/i
 
     condition:

--- a/assemblyline/common/identify_defaults.py
+++ b/assemblyline/common/identify_defaults.py
@@ -145,6 +145,7 @@ magic_patterns = [
     {"al_type": "network/tcpdump", "regex": r"^(tcpdump|pcap)"},
     {"al_type": "document/pdf", "regex": r"^pdf document"},
     {"al_type": "document/epub", "regex": r"^EPUB document"},
+    {"al_type": "document/mobi", "regex": r"^Mobipocket E-book"},
     {"al_type": "image/bmp", "regex": r"^pc bitmap"},
     {"al_type": "image/gif", "regex": r"^gif image data"},
     {"al_type": "image/jpg", "regex": r"^jpeg image data"},


### PR DESCRIPTION
More identification for CybercentreCanada/assemblyline/issues/203
This will cover both Mobi files and AZW3 files, which are based on Mobi files.
We currently cannot make a difference between the two of them based solely on the mime or magic.

Also added quick fix for batch identification with set command where the value starts with a %.