### PR TITLE
S3 IAM role based access

### DIFF
--- a/assemblyline/filestore/transport/s3.py
+++ b/assemblyline/filestore/transport/s3.py
@@ -113,7 +113,7 @@ class TransportS3(Transport):
             # Assume the role with web identity
             role = boto3.client("sts").assume_role_with_web_identity(
                 RoleArn=role_arn,
-                RoleSessionName="iam-role-session",
+                RoleSessionName="assemblyline",
                 WebIdentityToken=web_identity_token,
             )
 

--- a/assemblyline/filestore/transport/s3.py
+++ b/assemblyline/filestore/transport/s3.py
@@ -127,7 +127,7 @@ class TransportS3(Transport):
                 credentials["SessionToken"],
             )
         except Exception as e:
-            logging.error(f"Error assuming role with web identity: {e}")
+            self.log.error(f"Error assuming role with web identity: {e}")
             raise
 
     def __str__(self):


### PR DESCRIPTION
This adds an option to use S3 IAM role based authentication.  It will check if the accesstoken is none and if `AWS_WEB_IDENTITY_TOKEN_FILE` is set in the env.

Fixes https://github.com/CybercentreCanada/assemblyline/issues/209