### PR TITLE
Adding a value to OID_PARTS for distinguishing dns calls

### DIFF
--- a/assemblyline/odm/models/ontology/ontology.py
+++ b/assemblyline/odm/models/ontology/ontology.py
@@ -5,7 +5,7 @@ from assemblyline.odm.models.ontology.results import Antivirus, Process, Sandbox
 from assemblyline.odm.models.ontology.filetypes import PE
 
 Classification = forge.get_classification()
-ODM_VERSION = "1.8"
+ODM_VERSION = "1.9"
 
 
 @odm.model(description="File Characteristics")

--- a/assemblyline/odm/models/ontology/results/network.py
+++ b/assemblyline/odm/models/ontology/results/network.py
@@ -5,7 +5,7 @@ from assemblyline.common.dict_utils import get_dict_fingerprint_hash
 
 OID_PARTS = ['source_ip', 'source_port',
              'destination_ip', 'destination_port',
-             'transport_layer_protocol', 'connection_type', 'answer']
+             'transport_layer_protocol', 'connection_type', 'dns_details.domain']
 
 
 REQUEST_METHODS = [

--- a/assemblyline/odm/models/ontology/results/network.py
+++ b/assemblyline/odm/models/ontology/results/network.py
@@ -5,7 +5,7 @@ from assemblyline.common.dict_utils import get_dict_fingerprint_hash
 
 OID_PARTS = ['source_ip', 'source_port',
              'destination_ip', 'destination_port',
-             'transport_layer_protocol', 'connection_type', 'dns_details.domain']
+             'transport_layer_protocol', 'connection_type']
 
 
 REQUEST_METHODS = [
@@ -57,7 +57,19 @@ class NetworkConnection(odm.Model):
     connection_type = odm.Optional(odm.Enum(values=['http', 'dns', 'tls'], description="Type of connection being made"))
 
     def get_oid(data: dict):
-        return f"network_{get_dict_fingerprint_hash({key: data.get(key) for key in OID_PARTS})}"
+        connection_type = data.get('connection_type'):
+        hash_dict = {key: data.get(key) for key in OID_PARTS}
+        oid_prefix = "network"
+        if connection_type == "http":
+            # Include the requested URI as part of the hash
+            oid_prefix = "network_http"
+            hash_dict['http_details'] = {'request_uri': data.get('http_details', {}).get('request_uri', None)}
+        elif connection_type == "dns":
+            # Include the requested domain as part of the hash
+            oid_prefix = "network_dns"
+            hash_dict['dns_details'] = {'domain': data.get('dns_details', {}).get('domain', None)}
+
+        return f"{oid_prefix}_{get_dict_fingerprint_hash(hash_dict)}"
 
     def get_tag(data: dict):
         return f"{data.get('destination_ip')}:{data.get('destination_port')}"

--- a/assemblyline/odm/models/ontology/results/network.py
+++ b/assemblyline/odm/models/ontology/results/network.py
@@ -5,7 +5,7 @@ from assemblyline.common.dict_utils import get_dict_fingerprint_hash
 
 OID_PARTS = ['source_ip', 'source_port',
              'destination_ip', 'destination_port',
-             'transport_layer_protocol', 'connection_type']
+             'transport_layer_protocol', 'connection_type', 'answer']
 
 
 REQUEST_METHODS = [

--- a/assemblyline/odm/models/ontology/results/network.py
+++ b/assemblyline/odm/models/ontology/results/network.py
@@ -5,7 +5,7 @@ from assemblyline.common.dict_utils import get_dict_fingerprint_hash
 
 OID_PARTS = ['source_ip', 'source_port',
              'destination_ip', 'destination_port',
-             'transport_layer_protocol', 'connection_type', 'dns_details.domain']
+             'transport_layer_protocol', 'connection_type', 'dns_details.domain', 'http_details.request_uri']
 
 
 REQUEST_METHODS = [

--- a/assemblyline/odm/models/ontology/results/network.py
+++ b/assemblyline/odm/models/ontology/results/network.py
@@ -57,7 +57,7 @@ class NetworkConnection(odm.Model):
     connection_type = odm.Optional(odm.Enum(values=['http', 'dns', 'tls'], description="Type of connection being made"))
 
     def get_oid(data: dict):
-        connection_type = data.get('connection_type'):
+        connection_type = data.get('connection_type')
         hash_dict = {key: data.get(key) for key in OID_PARTS}
         oid_prefix = "network"
         if connection_type == "http":

--- a/assemblyline/odm/models/ontology/results/network.py
+++ b/assemblyline/odm/models/ontology/results/network.py
@@ -5,7 +5,7 @@ from assemblyline.common.dict_utils import get_dict_fingerprint_hash
 
 OID_PARTS = ['source_ip', 'source_port',
              'destination_ip', 'destination_port',
-             'transport_layer_protocol', 'connection_type']
+             'transport_layer_protocol', 'connection_type', 'dns_details.domain']
 
 
 REQUEST_METHODS = [

--- a/assemblyline/odm/models/ontology/results/network.py
+++ b/assemblyline/odm/models/ontology/results/network.py
@@ -72,8 +72,10 @@ class NetworkConnection(odm.Model):
         elif connection_type == "dns":
             # Include the requested domain as part of the hash
             oid_prefix = "network_dns"
-            hash_dict['dns_details'] = {'domain': data.get('dns_details', {}).get('domain', None)}
-            hash_dict['lookup_type'] = data.get('lookup_type', {})
+            hash_dict['dns_details'] = {
+              'domain': data.get('dns_details', {}).get('domain', None),
+              'lookup_type': data.get('dns_details', {}).get('lookup_type', None)
+            }
 
         return f"{oid_prefix}_{get_dict_fingerprint_hash(hash_dict)}"
 

--- a/assemblyline/odm/models/ontology/results/network.py
+++ b/assemblyline/odm/models/ontology/results/network.py
@@ -73,6 +73,7 @@ class NetworkConnection(odm.Model):
             # Include the requested domain as part of the hash
             oid_prefix = "network_dns"
             hash_dict['dns_details'] = {'domain': data.get('dns_details', {}).get('domain', None)}
+            hash_dict['lookup_type'] = {'type': data.get('lookup_type', {}).get('type', None)}
 
         return f"{oid_prefix}_{get_dict_fingerprint_hash(hash_dict)}"
 

--- a/assemblyline/odm/models/ontology/results/network.py
+++ b/assemblyline/odm/models/ontology/results/network.py
@@ -73,7 +73,7 @@ class NetworkConnection(odm.Model):
             # Include the requested domain as part of the hash
             oid_prefix = "network_dns"
             hash_dict['dns_details'] = {'domain': data.get('dns_details', {}).get('domain', None)}
-            hash_dict['lookup_type'] = {'type': data.get('lookup_type', {}).get('type', None)}
+            hash_dict['lookup_type'] = data.get('lookup_type', {})
 
         return f"{oid_prefix}_{get_dict_fingerprint_hash(hash_dict)}"
 

--- a/assemblyline/odm/models/ontology/results/network.py
+++ b/assemblyline/odm/models/ontology/results/network.py
@@ -61,9 +61,14 @@ class NetworkConnection(odm.Model):
         hash_dict = {key: data.get(key) for key in OID_PARTS}
         oid_prefix = "network"
         if connection_type == "http":
-            # Include the requested URI as part of the hash
             oid_prefix = "network_http"
-            hash_dict['http_details'] = {'request_uri': data.get('http_details', {}).get('request_uri', None)}
+            http_details = data.get('http_details', {})
+
+            # Include any details involved in the request for hashing
+            hash_dict['http_details'] = {
+                field: http_details.get(field)
+                for field in NetworkHTTP.fields().keys() if field.startswith('request_')
+            }
         elif connection_type == "dns":
             # Include the requested domain as part of the hash
             oid_prefix = "network_dns"

--- a/assemblyline/odm/models/ontology/results/network.py
+++ b/assemblyline/odm/models/ontology/results/network.py
@@ -5,7 +5,7 @@ from assemblyline.common.dict_utils import get_dict_fingerprint_hash
 
 OID_PARTS = ['source_ip', 'source_port',
              'destination_ip', 'destination_port',
-             'transport_layer_protocol', 'connection_type', 'dns_details.domain', 'http_details.request_uri']
+             'transport_layer_protocol', 'connection_type']
 
 
 REQUEST_METHODS = [


### PR DESCRIPTION
CAPE DNS calls have the same components for OID_PARTS which make them non unique. Adding a value to generate the an unique hash which is a discerning value between DNS calls.