### PR TITLE
Add config flag for boto client defaults for s3 filestore

### DIFF
--- a/assemblyline/filestore/__init__.py
+++ b/assemblyline/filestore/__init__.py
@@ -125,7 +125,7 @@ def create_transport(url, connection_attempts=None):
 
     elif scheme == 's3':
         valid_str_keys = ['aws_region', 's3_bucket']
-        valid_bool_keys = ['use_ssl', 'verify']
+        valid_bool_keys = ['use_ssl', 'verify', 'boto_defaults']
         extras = _get_extras(parse_qs(parsed.query), valid_str_keys=valid_str_keys, valid_bool_keys=valid_bool_keys)
 
         # If user/password not specified, access might be dictated by IAM roles

--- a/assemblyline/filestore/transport/s3.py
+++ b/assemblyline/filestore/transport/s3.py
@@ -32,7 +32,7 @@ class TransportS3(Transport):
     DEFAULT_HOST = "s3.amazonaws.com"
 
     def __init__(self, base=None, accesskey=None, secretkey=None, aws_region=None, s3_bucket="al-storage",
-                 host=None, port=None, use_ssl=None, verify=True, connection_attempts=None):
+                 host=None, port=None, use_ssl=None, verify=True, connection_attempts=None, boto_defaults=False):
         self.log = logging.getLogger('assemblyline.transport.s3')
         self.base = base
         self.bucket = s3_bucket
@@ -60,15 +60,23 @@ class TransportS3(Transport):
 
         with boto3_client_lock:
             session = boto3.session.Session()
-            self.client = session.client(
-                "s3",
-                aws_access_key_id=accesskey,
-                aws_secret_access_key=secretkey,
-                endpoint_url=self.endpoint_url,
-                region_name=aws_region,
-                use_ssl=self.use_ssl,
-                verify=verify,
-            )
+            if boto_defaults:
+                self.client = session.client(
+                    "s3",
+                    region_name=aws_region,
+                    use_ssl=self.use_ssl,
+                    verify=verify,
+                )
+            else:
+                self.client = session.client(
+                    "s3",
+                    aws_access_key_id=accesskey,
+                    aws_secret_access_key=secretkey,
+                    endpoint_url=self.endpoint_url,
+                    region_name=aws_region,
+                    use_ssl=self.use_ssl,
+                    verify=verify,
+                )
 
         bucket_exist = False
         try:


### PR DESCRIPTION
hey CCCS folks, this change is to allow the boto client to defer to the default credential load order which will be convienient for stuff like [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)

thank y'all for maintaining this awesome open source project!  