### PR TITLE
dev - Add logic to allow for service defined recursion prevention

### DIFF
--- a/assemblyline/odm/messages/task.py
+++ b/assemblyline/odm/messages/task.py
@@ -57,9 +57,14 @@ class Task(odm.Model):
     ignore_cache = odm.Boolean(
         default=False, description="Whether the service cache should be ignored during the processing of this task")
 
+    ignore_recursion_prevention = odm.Boolean(
+        default=False,
+        description="Whether the service should ignore recursion prevention or not")
+
+    # TODO: The following three lines can be removed after assemblyline upgrade to version 4.6+
     ignore_dynamic_recursion_prevention = odm.Boolean(
         default=False,
-        description="Whether the service should ignore the dynamic recursion prevention or not")
+        description="Whether the service should ignore dynamic recursion prevention or not")
 
     ignore_filtering = odm.Boolean(default=False, description="Should the service filter it's output?")
 

--- a/assemblyline/odm/models/service.py
+++ b/assemblyline/odm/models/service.py
@@ -167,3 +167,5 @@ class Service(odm.Model):
     update_config: UpdateConfig = odm.Optional(
         odm.Compound(UpdateConfig),
         description="Update configuration for fetching external resources")
+
+    recursion_prevention: list[str] = odm.sequence(odm.Keyword(), default=[], description="List of service names/categories where recursion is prevented.")

--- a/assemblyline/odm/models/service_delta.py
+++ b/assemblyline/odm/models/service_delta.py
@@ -124,3 +124,5 @@ class ServiceDelta(odm.Model):
 
     update_channel = odm.Optional(odm.Enum(values=["stable", "rc", "beta", "dev"]), description=REF_SERVICE)
     update_config: UpdateConfigDelta = odm.Optional(odm.Compound(UpdateConfigDelta), description=REF_SERVICE)
+
+    recursion_prevention = odm.Optional(odm.sequence(odm.Keyword()), description=REF_SERVICE)

--- a/assemblyline/odm/models/submission.py
+++ b/assemblyline/odm/models/submission.py
@@ -34,6 +34,8 @@ _KEY_HASHED_FIELDS = {
     'classification',
     'deep_scan',
     'ignore_cache',
+    'ignore_recursion_prevention',
+    # TODO: This one line can be removed after assemblyline upgrade to version 4.6+
     'ignore_dynamic_recursion_prevention',
     'ignore_filtering',
     'ignore_size',
@@ -51,8 +53,13 @@ class SubmissionParams(odm.Model):
     generate_alert = odm.Boolean(default=False, description="Should this submission generate an alert?")
     groups = odm.List(odm.Keyword(), default=[], description="List of groups related to this scan")
     ignore_cache = odm.Boolean(default=False, description="Ignore the cached service results?")
+    ignore_recursion_prevention = odm.Boolean(
+        default=False, description="Should we ignore recursion prevention?")
+
+    # TODO: The following three lines can be removed after assemblyline upgrade to 4.6+
     ignore_dynamic_recursion_prevention = odm.Boolean(
         default=False, description="Should we ignore dynamic recursion prevention?")
+
     ignore_filtering = odm.Boolean(default=False, description="Should we ignore filtering services?")
     ignore_size = odm.Boolean(default=False, description="Ignore the file size limits?")
     never_drop = odm.Boolean(default=False, description="Exempt from being dropped by ingester?")

--- a/assemblyline/odm/models/user_settings.py
+++ b/assemblyline/odm/models/user_settings.py
@@ -26,7 +26,10 @@ class UserSettings(odm.Model):
     expand_min_score = odm.Integer(default=500, description="Auto-expand section when score bigger then this")
     generate_alert = odm.Boolean(default=False, description="Generate an alert?")
     ignore_cache = odm.Boolean(default=False, description="Ignore service caching?")
+
+    #the following 1 line can be removed after assemblyline 4.6+
     ignore_dynamic_recursion_prevention = odm.Boolean(default=False, description="Ignore dynamic recursion prevention?")
+    ignore_recursion_prevention = odm.Boolean(default=False, description="Ignore all service recursion prevention?")
     ignore_filtering = odm.Boolean(default=False, description="Ignore filtering services?")
     malicious = odm.Boolean(default=False, description="Is the file submitted already known to be malicious?")
     priority = odm.Integer(default=1000, description="Default priority for the submissions")


### PR DESCRIPTION
Added logic for recursion prevention so that each service can define which services to prevent recursive analysis through the service manifest.