### PR TITLE
Check for lambda as python complex executor

### DIFF
--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -821,7 +821,7 @@ rule code_python {
 
         // High confidence one-liner used to execute base64 blobs
         // reference: https://github.com/DataDog/guarddog/blob/main/guarddog/analyzer/sourcecode/exec-base64.yml
-        $executor1 = /(exec|eval|check_output|run|call|[Pp]open|os\.system)\(((zlib|__import__\(['"]zlib['"]\))\.decompress\()?(base64|__import__\(['"]base64['"]\))\.b64decode\(/
+        $executor1 = /((exec|eval|check_output|run|call|[Pp]open|os\.system)\(|lambda\s+\w{1,100}\s*:\s*)((zlib|__import__\(['"]zlib['"]\))\.decompress\()?(base64|__import__\(['"]base64['"]\))\.b64decode\(/
         $executor2 = /(marshal|__import__\(['"]marshal['"]\)|pickle|__import__\(['"]pickle['"]\))\.loads\(zlib\.decompress\(/
 
     condition:


### PR DESCRIPTION
Addition of lambda instead of any other exec, eval, ... executors.
Will fix CybercentreCanada/assemblyline/issues/254