### PR TITLE
Adding more python identification techniques

### DIFF
--- a/assemblyline/common/custom.magic
+++ b/assemblyline/common/custom.magic
@@ -151,3 +151,8 @@
 # Apple Disk Image
 -512 string koly\x00\x00\x00\x04\x00\x00\x02\x00 custom: archive/dmg
 !:mime	application/x-apple-diskimage
+# Python interpreters
+0 string \#\!\/bin\/python custom: code/python
+0 string \#\!\/usr\/bin\/python custom: code/python
+0 string \#\!\/usr\/local\/bin\/python custom: code/python
+0 string \#\!\/usr\/bin\/env\ python custom: code/python

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -821,9 +821,8 @@ rule code_python {
 
         // High confidence one-liner used to execute base64 blobs
         // reference: https://github.com/DataDog/guarddog/blob/main/guarddog/analyzer/sourcecode/exec-base64.yml
-        $executor1 = /((exec|eval|check_output|run|call|[Pp]open|os\.system)\(|lambda[ \t]+\w{1,100}[ \t]*:[ \t]*)((zlib|__import__\(['"]zlib['"]\))\.decompress\()?(base64|__import__\(['"]base64['"]\))\.b64decode\(/
+        $executor1 = /((exec|eval|check_output|run|call|[Pp]open|os\.system)\(|lambda[ \t]+\w{1,100}[ \t]*:[ \t]*)((zlib|__import__\((['"]zlib['"]|['"]\\x0*7a\\x0*6c\\x0*69\\x0*62['"]|['"]\\0*172\\0*154\\0*151\\0*142['"])\))\.decompress\()?(base64|__import__\((['"]base64['"]|['"]\\x0*62\\x0*61\\x0*73\\x0*65\\x0*36\\x0*34['"]|['"]\\0*142\\0*141\\0*163\\0*145\\0*66\\0*64['"])\))\.b64decode\(/
         $executor2 = /(marshal|__import__\(['"]marshal['"]\)|pickle|__import__\(['"]pickle['"]\))\.loads\(/
-        $executor3 = /(^|\n)[ \t]*((exec|eval|check_output|run|call|[Pp]open|os\.system)\(|lambda[ \t]+\w{1,100}[ \t]*:[ \t]*)__import__\(/
 
     condition:
         mime startswith "text"

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -821,8 +821,9 @@ rule code_python {
 
         // High confidence one-liner used to execute base64 blobs
         // reference: https://github.com/DataDog/guarddog/blob/main/guarddog/analyzer/sourcecode/exec-base64.yml
-        $executor1 = /((exec|eval|check_output|run|call|[Pp]open|os\.system)\(|lambda\s+\w{1,100}\s*:\s*)((zlib|__import__\(['"]zlib['"]\))\.decompress\()?(base64|__import__\(['"]base64['"]\))\.b64decode\(/
-        $executor2 = /(marshal|__import__\(['"]marshal['"]\)|pickle|__import__\(['"]pickle['"]\))\.loads\(zlib\.decompress\(/
+        $executor1 = /((exec|eval|check_output|run|call|[Pp]open|os\.system)\(|lambda[ \t]+\w{1,100}[ \t]*:[ \t]*)((zlib|__import__\(['"]zlib['"]\))\.decompress\()?(base64|__import__\(['"]base64['"]\))\.b64decode\(/
+        $executor2 = /(marshal|__import__\(['"]marshal['"]\)|pickle|__import__\(['"]pickle['"]\))\.loads\(/
+        $executor3 = /(^|\n)[ \t]*((exec|eval|check_output|run|call|[Pp]open|os\.system)\(|lambda[ \t]+\w{1,100}[ \t]*:[ \t]*)__import__\(/
 
     condition:
         mime startswith "text"

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -822,7 +822,7 @@ rule code_python {
         // High confidence one-liner used to execute base64 blobs
         // reference: https://github.com/DataDog/guarddog/blob/main/guarddog/analyzer/sourcecode/exec-base64.yml
         $executor1 = /((exec|eval|check_output|run|call|[Pp]open|os\.system)\(|lambda[ \t]+\w{1,100}[ \t]*:[ \t]*)((zlib|__import__\((['"]zlib['"]|['"]\\x0*7a\\x0*6c\\x0*69\\x0*62['"]|['"]\\0*172\\0*154\\0*151\\0*142['"])\))\.decompress\()?(base64|__import__\((['"]base64['"]|['"]\\x0*62\\x0*61\\x0*73\\x0*65\\x0*36\\x0*34['"]|['"]\\0*142\\0*141\\0*163\\0*145\\0*66\\0*64['"])\))\.b64decode\(/
-        $executor2 = /(marshal|__import__\(['"]marshal['"]\)|pickle|__import__\(['"]pickle['"]\))\.loads\(/
+        $executor2 = /(marshal|__import__\((['"]marshal['"]|['"]\\x0*6d\\x0*61\\x0*72\\x0*73\\x0*68\\x0*61\\x0*6c['"]|['"]\\0*155\\0*141\\0*162\\0*163\\0*150\\0*141\\0*154['"])\)|pickle|__import__\((['"]pickle['"]|['"]\\x0*70\\x0*69\\x0*63\\x0*6b\\x0*6c\\x0*65['"]|['"]\\0*160\\0*151\\0*143\\0*153\\0*154\\0*145['"])\))\.loads\(/
 
     condition:
         mime startswith "text"


### PR DESCRIPTION
There are always more samples that evade identification.
Those modifications are at minima covering the two raised by [issue 257](https://github.com/CybercentreCanada/assemblyline/issues/257).

I added some alternative ways to write base64 and zlib for executor1.

I loosened executor2 so that it didn't the need internal zlib call.
Will need to check that it won't bring in too many false positives.