### PR TITLE
Add support Federated Identity Credential token when using Azure AD

### DIFF
--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -210,11 +210,11 @@ class OAuthProvider(odm.Model):
     redirect_uri: str = odm.Optional(odm.Keyword(),
                                      description="URI to redirect to after authentication with OAuth provider")
     request_token_url: str = odm.Optional(odm.Keyword(), description="URL to request token")
-    request_token_params: str = odm.Optional(odm.Keyword(), description="Parameters to request token")
+    request_token_params: Dict[str, str] = odm.Optional(odm.Mapping(odm.Keyword()),description="Parameters to request token")
     access_token_url: str = odm.Optional(odm.Keyword(), description="URL to get access token")
-    access_token_params: str = odm.Optional(odm.Keyword(), description="Parameters to get access token")
+    access_token_params: Dict[str, str] = odm.Optional(odm.Mapping(odm.Keyword()), description="Parameters to get access token")
     authorize_url: str = odm.Optional(odm.Keyword(), description="URL used to authorize access to a resource")
-    authorize_params: str = odm.Optional(odm.Keyword(), description="Parameters used to authorize access to a resource")
+    authorize_params: Dict[str, str] = odm.Optional(odm.Mapping(odm.Keyword()),description="Parameters used to authorize access to a resource")
     api_base_url: str = odm.Optional(odm.Keyword(), description="Base URL for downloading the user's and groups info")
     client_kwargs: Dict[str, str] = odm.Optional(odm.Mapping(odm.Keyword()),
                                                  description="Keyword arguments passed to the different URLs")

--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -203,7 +203,6 @@ class OAuthProvider(odm.Model):
         description="Regex used to parse an email address and capture parts to create a user ID out of it")
     uid_format: str = odm.Optional(odm.Keyword(),
                                    description="Format of the user ID based on the captured parts from the regex")
-
     client_id: str = odm.Optional(odm.Keyword(),
                                   description="ID of your application to authenticate to the OAuth provider")
     client_secret: str = odm.Optional(odm.Keyword(),
@@ -240,6 +239,9 @@ class OAuthProvider(odm.Model):
     username_field: str = odm.Keyword(default='uname', description="Name of the field that will contain the username")
     validate_token_with_secret: bool = odm.Boolean(
         default=False, description="Should we send the client secret while validating the access token?")
+    aad_fic_token_file_path: str = odm.Optional(
+        odm.Keyword(),
+        description="Path to the token file for authentication using Azure AD Federated Identity Credentials")
 
 
 DEFAULT_OAUTH_PROVIDER_AZURE = {


### PR DESCRIPTION
Replaces use on client secret by a password-less authentication setup using Federated Identities