### PR TITLE
add default zip password and allow for zip option in config

### DIFF
--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -1745,7 +1745,7 @@ DEFAULT_UI = {
     "default_quotas": DEFAULT_QUOTAS,
     "discover_url": None,
     "download_encoding": "cart",
-    "default_zip_password": "zippy",
+    "default_zip_password": "infected",
     "email": None,
     "enforce_quota": True,
     "external_links": [],

--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -1662,7 +1662,7 @@ class APIProxies(odm.Model):
 
 
 DEFAULT_API_PROXIES = {}
-
+DOWNLOAD_ENCODINGS = ["cart", "raw", "zip"]
 
 @odm.model(index=False, store=False, description="UI Configuration")
 class UI(odm.Model):
@@ -1690,7 +1690,8 @@ class UI(odm.Model):
     default_quotas: Quotas = odm.Compound(Quotas, default=DEFAULT_QUOTAS,
                                           description="Default API quotas values")
     discover_url: str = odm.Optional(odm.Keyword(), description="Discover URL")
-    download_encoding = odm.Enum(values=["raw", "cart"], description="Which encoding will be used for downloads?")
+    download_encoding = odm.Enum(values=DOWNLOAD_ENCODINGS, description="Which encoding will be used for downloads?")
+    default_zip_password = odm.Optional(odm.Text(), description="Default user-defined password for creating password protected ZIPs when downloading files")
     email: str = odm.Optional(odm.Email(), description="Assemblyline admins email address")
     enforce_quota: bool = odm.Boolean(description="Enforce the user's quotas?")
     external_links: List[ExternalLinks] = odm.List(
@@ -1744,6 +1745,7 @@ DEFAULT_UI = {
     "default_quotas": DEFAULT_QUOTAS,
     "discover_url": None,
     "download_encoding": "cart",
+    "default_zip_password": "zippy",
     "email": None,
     "enforce_quota": True,
     "external_links": [],

--- a/assemblyline/odm/models/user_settings.py
+++ b/assemblyline/odm/models/user_settings.py
@@ -19,7 +19,7 @@ class UserSettings(odm.Model):
     default_external_sources = odm.List(odm.Keyword(), default=[],
                                         description="List of sha256 sources to check by default")
     default_zip_password = odm.Text(
-        default="zippy",
+        default="infected",
         description="Default user-defined password for creating password protected ZIPs when downloading files"
     )
     executive_summary = odm.Boolean(default=True, description="Should executive summary sections be shown?")

--- a/assemblyline/odm/random_data/__init__.py
+++ b/assemblyline/odm/random_data/__init__.py
@@ -405,7 +405,7 @@ def create_users(ds, log=None):
         "type": [TYPES.admin]})
     ds.user.save('admin', user_data)
     ds.user_settings.save('admin', UserSettings({"ignore_cache": True, "deep_scan": True,
-                                                 "default_zip_password": "zippy", "default_download_encoding": "cart"}))
+                                                 "default_zip_password": "infected", "default_download_encoding": "cart"}))
     if log:
         log.info(f"\tU:{user_data.uname}   P:{admin_pass}")
 
@@ -417,7 +417,7 @@ def create_users(ds, log=None):
         "uname": "user",
         "type": [TYPES.user]})
     ds.user.save('user', user_data)
-    ds.user_settings.save('user', UserSettings({"default_zip_password": "zippy", "default_download_encoding": "cart"}))
+    ds.user_settings.save('user', UserSettings({"default_zip_password": "infected", "default_download_encoding": "cart"}))
     if log:
         log.info(f"\tU:{user_data.uname}   P:{user_pass}")
 

--- a/assemblyline/odm/random_data/__init__.py
+++ b/assemblyline/odm/random_data/__init__.py
@@ -404,7 +404,8 @@ def create_users(ds, log=None):
         "uname": "admin",
         "type": [TYPES.admin]})
     ds.user.save('admin', user_data)
-    ds.user_settings.save('admin', UserSettings({"ignore_cache": True, "deep_scan": True}))
+    ds.user_settings.save('admin', UserSettings({"ignore_cache": True, "deep_scan": True,
+                                                 "default_zip_password": "zippy", "default_download_encoding": "cart"}))
     if log:
         log.info(f"\tU:{user_data.uname}   P:{admin_pass}")
 
@@ -416,7 +417,7 @@ def create_users(ds, log=None):
         "uname": "user",
         "type": [TYPES.user]})
     ds.user.save('user', user_data)
-    ds.user_settings.save('user', UserSettings())
+    ds.user_settings.save('user', UserSettings({"default_zip_password": "zippy", "default_download_encoding": "cart"}))
     if log:
         log.info(f"\tU:{user_data.uname}   P:{user_pass}")
 


### PR DESCRIPTION
add default zip password to UI configuration.

Add the ability to configure default zip password in `config.yaml`.
Add `zip` as an option in UI configuration.

This is to address https://github.com/CybercentreCanada/assemblyline/issues/274