### PR TITLE
Fallback to mimetype when yara identification yielded no conclusive result

### DIFF
--- a/assemblyline/common/identify.py
+++ b/assemblyline/common/identify.py
@@ -22,7 +22,7 @@ import yara
 
 from assemblyline.common.digests import DEFAULT_BLOCKSIZE, get_digests_for_file
 from assemblyline.common.forge import get_cachestore, get_config, get_constants, get_datastore
-from assemblyline.common.identify_defaults import OLE_CLSID_GUIDs
+from assemblyline.common.identify_defaults import OLE_CLSID_GUIDs, untrusted_mimes
 from assemblyline.common.identify_defaults import magic_patterns as default_magic_patterns
 from assemblyline.common.identify_defaults import trusted_mimes as default_trusted_mimes
 from assemblyline.common.str_utils import dotdump, safe_str
@@ -391,6 +391,10 @@ class Identify:
 
             # Only if the file was not identified as a csv or a json
             data["type"] = self.yara_ident(path, data, fallback=data["type"])
+
+            if ("unknown" in data["type"] or data["type"] == "text/plain") and data["mime"] in untrusted_mimes:
+                # Rely on untrusted mimes
+                data["type"] = untrusted_mimes[data["mime"]]
 
         # Extra checks for office documents
         #  - Check for encryption

--- a/assemblyline/common/identify_defaults.py
+++ b/assemblyline/common/identify_defaults.py
@@ -447,3 +447,12 @@ trusted_mimes = {
     # Android
     "application/vnd.android.package-archive": "android/apk",
 }
+
+# LibMagic mimetypes that we will fallback to when we can't determine a type
+untrusted_mimes = {
+    "application/javascript": "code/javascript",
+    "text/x-java": "code/java",
+    "text/html": "code/html",
+    "text/x-c++": "code/c++",
+    "text/x-c": "code/c",
+}


### PR DESCRIPTION
Fix for two javascript files found in [this issue](https://github.com/CybercentreCanada/assemblyline/issues/284).