### PR TITLE
Fix old python version issues

### DIFF
--- a/assemblyline/odm/models/service_delta.py
+++ b/assemblyline/odm/models/service_delta.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from assemblyline import odm
 from assemblyline.odm.models.service import SIGNATURE_DELIMITERS, FETCH_METHODS
 
@@ -56,6 +58,7 @@ class UpdateSourceDelta(odm.Model):
     configuration = odm.Optional(odm.Mapping(odm.Any(), default={}), description=REF_UPDATE_SOURCE)
     update_interval = odm.Optional(odm.Integer(min=0), description=REF_UPDATE_SOURCE)
     ignore_cache = odm.Optional(odm.Boolean(default=False), description=REF_UPDATE_SOURCE)
+
 
 @ odm.model(index=False, store=False)
 class PersistentVolumeDelta(odm.Model):

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,6 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Libraries',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
- import annotations from __future__ in service_delta, required to use the | for union type hints in python 3.9
- Remove py3.7, py3.8 mention in setup.py. They are depricated and no longer supported