### PR TITLE
feat: add enable_pod_security flag for scaler odm model

### DIFF
--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -929,6 +929,10 @@ class Scaler(odm.Model):
     cluster_pod_list = odm.boolean(default=True, description="Sets if scaler list pods for all namespaces. "
                                    "Disabling this lets you use stricter cluster roles but will make cluster resource "
                                    "usage less accurate, setting a namespace resource quota might be needed.")
+    enable_pod_security = odm.boolean(
+        default=False,
+        description="Launch all containers in compliance with the 'Restricted' pod security standard.",
+    )
 
 
 DEFAULT_SCALER = {


### PR DESCRIPTION
Add `enable_pod_security` flag for scaler and updater.
When set to true, this will launch all containers in compliance with the 'Restricted' pod security standard.

Related to change to scaler and updater: https://github.com/CybercentreCanada/assemblyline-core/pull/1042 