### PR TITLE
Fix strong_vbs12 fullword and improve strong_vbs3 with :

### DIFF
--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -167,7 +167,7 @@ rule code_vbs {
         $strong_vbs2 = /(^|\n|\()(Private|Public)?[ \t]*(Sub|Function)[ \t]+\w+\([ \t]*((ByVal[ \t]+)?\w+([ \t]+As[ \t]+\w+)?,?)*\)[ \t]*[\)\r]/i ascii wide
         // Supported by https://github.com/CERT-Polska/karton-classifier/blob/4cf125296e3a0c1d6c1cb8c16f97d608054c7f19/karton/classifier/classifier.py#L650
         // Supported by https://github.com/CAPESandbox/sflock/blob/1e0ed7e18ddfe723c2d2603875ca26d63887c189/sflock/ident.py#L485
-        $strong_vbs3 = /(^|\n)[ \t]*End[ \t]+(Module|Function|Sub|If)($|\s)/i ascii wide
+        $strong_vbs3 = /(^|\n|:)[ \t]*End[ \t]+(Module|Function|Sub|If)($|\s)/i ascii wide
         $strong_vbs4 = "\nExecuteGlobal" ascii wide
         // Supported by https://github.com/CAPESandbox/sflock/blob/1e0ed7e18ddfe723c2d2603875ca26d63887c189/sflock/ident.py#L485
         $strong_vbs6 = /(^|\n|:)(Attribute|Set|const)[ \t]+\w+[ \t]+=/i ascii wide
@@ -179,7 +179,7 @@ rule code_vbs {
         $strong_vbs10 = "GetObject(" nocase ascii wide
         $strong_vbs11 = "\nEval(" nocase ascii wide
         // Supported by https://github.com/CERT-Polska/karton-classifier/blob/4cf125296e3a0c1d6c1cb8c16f97d608054c7f19/karton/classifier/classifier.py#L650
-        $strong_vbs12 = "Execute(" nocase ascii wide fullword
+        $strong_vbs12 = /\bExecute\(/ nocase ascii wide
         $strong_vbs13 = "\nMsgBox \"" nocase ascii wide
         // Inspired by https://github.com/CERT-Polska/karton-classifier/blob/4cf125296e3a0c1d6c1cb8c16f97d608054c7f19/karton/classifier/classifier.py#L650
         $strong_vbs14 = /[ \t(=]Array\(/i ascii wide


### PR DESCRIPTION
Fullword doesn't work as intented with a final parenthesis for matching function calls. Switching to a regex with the intended behaviour. Adding `:` to the list of "line start" characters for strong_vbs3 to match `: End Sub` and the like.