### PR TITLE
Bump code_ps1_small size to 12 KiB

### DIFF
--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -710,7 +710,7 @@ rule code_ps1_small {
         $power = "powershell" nocase fullword
 
     condition:
-        filesize < 8192
+        filesize < 12288
         and $power at 0
 }
 


### PR DESCRIPTION
Some files are just outside the 8 KiB limit.