### PR TITLE
General improvements

### DIFF
--- a/assemblyline/common/bundling.py
+++ b/assemblyline/common/bundling.py
@@ -6,15 +6,17 @@ import shutil
 import subprocess
 import tempfile
 import time
-
 from copy import copy
-from assemblyline.common.isotime import now_as_iso
-from cart import pack_stream, unpack_stream, is_cart
+
+from cart import is_cart, pack_stream, unpack_stream
 
 from assemblyline.common import forge
+from assemblyline.common.classification import InvalidClassification
+from assemblyline.common.isotime import now_as_iso
 from assemblyline.common.uid import get_random_id
 from assemblyline.datastore.exceptions import MultiKeyError
 from assemblyline.filestore import FileStoreException
+
 try:
     from assemblyline_core.submission_client import SubmissionClient
 except ImportError:
@@ -251,7 +253,7 @@ def create_bundle(sid, working_dir=WORK_DIR, use_alert=False):
 
 # noinspection PyBroadException,PyProtectedMember
 def import_bundle(path, working_dir=WORK_DIR, min_classification=Classification.UNRESTRICTED, allow_incomplete=False,
-                  rescan_services=None, exist_ok=False, cleanup=True, identify=None):
+                  rescan_services=None, exist_ok=False, cleanup=True, identify=None, reclassification=None):
     with forge.get_datastore(archive_access=True) as datastore:
         current_working_dir = os.path.join(working_dir, get_random_id())
         res_file = os.path.join(current_working_dir, "results.json")
@@ -288,6 +290,18 @@ def import_bundle(path, working_dir=WORK_DIR, min_classification=Classification.
         alert = data.get('alert', None)
         submission = data.get('submission', None)
 
+        def check_classification(document: dict):
+            try:
+                document['classification'] = Classification.max_classification(document['classification'],
+                                                                               min_classification)
+            except InvalidClassification:
+                if reclassification:
+                    # If the classification is invalid, we try to reclassify it if reclassification is provided
+                    document['classification'] = reclassification
+                else:
+                    # If we cannot reclassify it, we raise an exception
+                    raise
+
         try:
             if submission:
                 sid = submission['sid']
@@ -315,10 +329,12 @@ def import_bundle(path, working_dir=WORK_DIR, min_classification=Classification.
                 # Check if the submission does not already exist
                 if not datastore.submission.exists(sid):
                     # Make sure bundle's submission meets minimum classification and save the submission
-                    submission['classification'] = Classification.max_classification(submission['classification'],
-                                                                                     min_classification)
+                    original_classification = submission['classification']
+                    check_classification(submission)
+
                     submission.setdefault('metadata', {})
                     submission['metadata']['bundle.loaded'] = now_as_iso()
+                    submission['metadata']['bundle.classification'] = original_classification
                     submission['metadata'].pop('replay', None)
                     submission.update(Classification.get_access_control_parts(submission['classification']))
 
@@ -329,9 +345,8 @@ def import_bundle(path, working_dir=WORK_DIR, min_classification=Classification.
                     # Make sure files meet minimum classification and save the files
                     with forge.get_filestore() as filestore:
                         for f, f_data in files['infos'].items():
-                            f_classification = Classification.max_classification(
-                                f_data['classification'], min_classification)
-                            datastore.save_or_freshen_file(f, f_data, f_data['expiry_ts'], f_classification,
+                            check_classification(f_data)
+                            datastore.save_or_freshen_file(f, f_data, f_data['expiry_ts'], f_data['classification'],
                                                            cl_engine=Classification)
                             try:
                                 filestore.upload(os.path.join(current_working_dir, f), f)
@@ -344,8 +359,7 @@ def import_bundle(path, working_dir=WORK_DIR, min_classification=Classification.
                                 datastore.emptyresult.save(key, {"expiry_ts": now_as_iso(
                                     config.submission.emptyresult_dtl * 24 * 60 * 60)})
                             else:
-                                res['classification'] = Classification.max_classification(
-                                    res['classification'], min_classification)
+                                check_classification(res)
                                 datastore.result.save(key, res)
 
                         # Make sure errors meet minimum classification and save the errors
@@ -368,11 +382,11 @@ def import_bundle(path, working_dir=WORK_DIR, min_classification=Classification.
 
             # Save alert if present and does not exist
             if alert and not datastore.alert.exists(alert['alert_id']):
-                alert['classification'] = Classification.max_classification(alert['classification'],
-                                                                            min_classification)
+                original_classification = alert['classification']
+                check_classification(alert)
                 alert.setdefault('metadata', {})
                 alert['metadata']['bundle.loaded'] = now_as_iso()
-
+                alert['metadata']['bundle.classification'] = original_classification
                 alert['metadata'].pop('replay', None)
                 alert['workflows_completed'] = False
 

--- a/assemblyline/common/bundling.py
+++ b/assemblyline/common/bundling.py
@@ -292,6 +292,7 @@ def import_bundle(path, working_dir=WORK_DIR, min_classification=Classification.
 
         def check_classification(document: dict):
             try:
+                document['classification'] = Classification.normalize_classification(document['classification'])
                 document['classification'] = Classification.max_classification(document['classification'],
                                                                                min_classification)
             except InvalidClassification:

--- a/assemblyline/common/bundling.py
+++ b/assemblyline/common/bundling.py
@@ -88,7 +88,7 @@ def get_results(keys, file_infos_p, storage_p, user_classification):
 
     results = {}
     for k, v in res.items():
-        if not Classification.is_accessible(user_classification, v['classification']):
+        if user_classification and not Classification.is_accessible(user_classification, v['classification']):
             # Skip results a user doesn't have access to
             missing.append(k)
             continue

--- a/assemblyline/datastore/helper.py
+++ b/assemblyline/datastore/helper.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 from datetime import datetime
 from typing import Any, List, Optional, Tuple, Union
 
-from assemblyline.odm.models.apikey import Apikey
 import elasticapm
 
 from assemblyline.common import forge
@@ -21,6 +20,7 @@ from assemblyline.datastore.store import ESStore
 from assemblyline.filestore import FileStore
 from assemblyline.odm import DATEFORMAT, Date, Model
 from assemblyline.odm.models.alert import Alert
+from assemblyline.odm.models.apikey import Apikey
 from assemblyline.odm.models.badlist import Badlist
 from assemblyline.odm.models.cached_file import CachedFile
 from assemblyline.odm.models.config import METADATA_FIELDTYPE_MAP, Metadata
@@ -1307,9 +1307,10 @@ class AssemblylineDatastore(object):
 
             # Loading JSON formatted sections
             body_format = section['body_format']
-            if body_format in JSON_SECTIONS and isinstance(section['body'], str):
+            section_body = section.get('body')
+            if body_format in JSON_SECTIONS and isinstance(section_body, str):
                 try:
-                    section['body'] = json.loads(section['body'])
+                    section['body'] = json.loads(section_body)
                 except ValueError:
                     pass
 

--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -2049,10 +2049,9 @@ DEFAULT_SUBMISSION_PROFILES = [
     {
         # Only perform static analysis
         "name": "static",
-        "display_name": "Static Analysis",
+        "display_name": "[OFFLINE] Static Analysis",
         "params": {
             "services": {
-                "excluded": ["Dynamic Analysis", "Internet Connected"],
                 "selected": DEFAULT_SRV_SEL
             }
         },
@@ -2061,10 +2060,9 @@ DEFAULT_SUBMISSION_PROFILES = [
     {
         # Perform static analysis along with dynamic analysis
         "name": "static_with_dynamic",
-        "display_name": "Static + Dynamic Analysis",
+        "display_name": "[OFFLINE] Static + Dynamic Analysis",
         "params": {
             "services": {
-                "excluded": ["Internet Connected"],
                 "selected": DEFAULT_SRV_SEL + ["Dynamic Analysis"]
             }
         },
@@ -2073,14 +2071,32 @@ DEFAULT_SUBMISSION_PROFILES = [
     {
         # Perform static analysis along with internet connected services
         "name": "static_with_internet",
-        "display_name": "Internet-Connected Static Analysis",
+        "display_name": "[ONLINE] Static Analysis",
         "params": {
             "services": {
-                "excluded": ["Dynamic Analysis"],
                 "selected": DEFAULT_SRV_SEL + ["Internet Connected"]
             },
         },
         "description": "Combine traditional static analysis techniques with internet-connected services to gather additional information and context about the file being analyzed."
+    },
+    {
+        # Perform static + dynamic analysis with internet connectivity
+        "name": "static_and_dynamic_with_internet",
+        "display_name": "[ONLINE] Static + Dynamic Analysis",
+        "params": {
+            "services": {
+                "selected": DEFAULT_SRV_SEL + ["Internet Connected", "Dynamic Analysis"]
+            },
+            "service_spec": {
+                "CAPE": {
+                    "routing": "internet"
+                },
+                "URLDownloader": {
+                    "proxy": "localhost_proxy"
+                }
+            }
+        },
+        "description": "Perform comprehensive file analysis using traditional static and dynamic analysis techniques with internet access."
     },
 ]
 

--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -1847,6 +1847,7 @@ class FileSource(odm.Model):
     select_services: bool = odm.List(odm.keyword(),
                                      default=[], description="List of services that will be auto-selected when using this source.")
     verify: bool = odm.Boolean(default=True, description="Should the download function Verify SSL connections?")
+    password: str = odm.Optional(odm.Text(description="Password to use for the downloaded file (ie. password-protected zip)"))
 
 
 EXAMPLE_FILE_SOURCE_VT = {
@@ -1859,14 +1860,6 @@ EXAMPLE_FILE_SOURCE_VT = {
     "headers": {"x-apikey": "YOUR_KEY"},
 }
 
-EXAMPLE_SHA256_SOURCE_VT = {
-    # This is an example on how this would work with VirusTotal
-    "name": "VirusTotal",
-    "url": r"https://www.virustotal.com/api/v3/files/{SHA256}/download",
-    "replace_pattern": r"{SHA256}",
-    "headers": {"x-apikey": "YOUR_KEY"},
-}
-
 EXAMPLE_SHA256_SOURCE_MB = {
     # This is an example on how this would work with Malware Bazaar
     "name": "Malware Bazaar",
@@ -1875,7 +1868,8 @@ EXAMPLE_SHA256_SOURCE_MB = {
     "data": r"query=get_file&sha256_hash={SHA256}",
     "method": "POST",
     "replace_pattern": r"{SHA256}",
-    "failure_pattern": '"query_status": "file_not_found"'
+    "failure_pattern": '"query_status": "file_not_found"',
+    "password": "infected"
 }
 
 EXAMPLE_SHA256_SOURCE_VS = {

--- a/assemblyline/odm/models/replay.py
+++ b/assemblyline/odm/models/replay.py
@@ -21,8 +21,9 @@ DEFAULT_CLIENT_OPTIONS = {
 
 @odm.model(index=False, store=False)
 class Client(odm.Model):
-    type: str = odm.Enum(['api', 'direct'])
-    options = odm.Optional(odm.Compound(ClientOptions, default=DEFAULT_CLIENT_OPTIONS))
+    type: str = odm.Enum(['api', 'direct'], description="Type of client to use for Replay operations")
+    options = odm.Optional(odm.Compound(ClientOptions, default=DEFAULT_CLIENT_OPTIONS),
+                           description="Options for the client")
 
 
 DEFAULT_CLIENT = {
@@ -31,11 +32,11 @@ DEFAULT_CLIENT = {
 }
 
 
-@odm.model(index=False, store=False)
+@odm.model(index=False, store=False, description="Input module configuration model for Replay creator operations")
 class InputModule(odm.Model):
-    enabled: bool = odm.Boolean()
-    threads: int = odm.Integer()
-    filter_queries = odm.List(odm.Keyword())
+    enabled: bool = odm.Boolean(description="Is this input module enabled?")
+    threads: int = odm.Integer(description="Number of threads to use for this input module",)
+    filter_queries = odm.List(odm.Keyword(), description="List of filter queries to apply to this input module")
 
 
 DEFAULT_INPUT = {
@@ -62,18 +63,19 @@ DEFAULT_SUBMISSION_INPUT = {
 }
 
 
-@odm.model(index=False, store=False)
+@odm.model(index=False, store=False, description="Replay creator configuration model")
 class Creator(odm.Model):
-    client = odm.Compound(Client, default=DEFAULT_CLIENT)
-    alert_input = odm.Compound(InputModule, default=DEFAULT_ALERT_INPUT)
-    badlist_input = odm.Compound(InputModule, default=DEFAULT_INPUT)
-    safelist_input = odm.Compound(InputModule, default=DEFAULT_INPUT)
-    signature_input = odm.Compound(InputModule, default=DEFAULT_INPUT)
-    submission_input = odm.Compound(InputModule, default=DEFAULT_SUBMISSION_INPUT)
-    workflow_input = odm.Compound(InputModule, default=DEFAULT_INPUT)
-    lookback_time: str = odm.Keyword()
-    output_filestore: str = odm.Keyword()
-    working_directory: str = odm.Keyword()
+    client = odm.Compound(Client, default=DEFAULT_CLIENT, description="Client to use for Replay operations")
+    alert_input = odm.Compound(InputModule, default=DEFAULT_ALERT_INPUT, description="Input module for alerts")
+    badlist_input = odm.Compound(InputModule, default=DEFAULT_INPUT, description="Input module for badlist items")
+    safelist_input = odm.Compound(InputModule, default=DEFAULT_INPUT, description="Input module for safelist items")
+    signature_input = odm.Compound(InputModule, default=DEFAULT_INPUT, description="Input module for signatures")
+    submission_input = odm.Compound(InputModule, default=DEFAULT_SUBMISSION_INPUT,
+                                    description="Input module for submissions")
+    workflow_input = odm.Compound(InputModule, default=DEFAULT_INPUT, description="Input module for workflows")
+    lookback_time: str = odm.Keyword(description="Lookback time for the Replay creator, e.g., '1d' for one day")
+    output_filestore: str = odm.Keyword(description="Output filestore URI for the Replay creator, e.g., 'file:///tmp/replay/output'")
+    working_directory: str = odm.Keyword(description="Working directory for the Replay creator, e.g., '/tmp/replay/work'")
 
 
 DEFAULT_CREATOR = {
@@ -89,15 +91,16 @@ DEFAULT_CREATOR = {
 }
 
 
-@odm.model(index=False, store=False)
+@odm.model(index=False, store=False, description="Replay loader configuration model")
 class Loader(odm.Model):
-    client = odm.Compound(Client, default=DEFAULT_CLIENT)
-    failed_directory: str = odm.Keyword()
-    input_threads: int = odm.Integer()
-    input_directory: str = odm.Keyword()
-    min_classification: str = odm.Optional(odm.Keyword())
-    rescan: List[str] = odm.List(odm.Keyword())
-    working_directory: str = odm.Keyword()
+    client = odm.Compound(Client, default=DEFAULT_CLIENT, description="Client to use for Replay loader operations")
+    failed_directory: str = odm.Keyword(description="Directory to store failed Replay bundles")
+    input_threads: int = odm.Integer(description="Number of threads to use for loading input bundles",)
+    input_directory: str = odm.Keyword(description="Directory to load input Replay bundles from")
+    min_classification: str = odm.Optional(odm.ClassificationString(), description="Minimum classification level for Replay bundles to be processed")
+    reclassification: str = odm.Optional(odm.ClassificationString(), description="Classification level to reclassify Replay bundles to after being imported")
+    rescan: List[str] = odm.List(odm.Keyword(), description="List of services to rescan after importing Replay bundles")
+    working_directory: str = odm.Keyword(description="Working directory for the Replay loader, e.g., '/tmp/replay/work'")
     sync_check_interval: int = odm.Integer(default=3600,
                                            description='How often to check on imported Replay bundles (in seconds)?')
 

--- a/docker/al_dev/Dockerfile
+++ b/docker/al_dev/Dockerfile
@@ -7,7 +7,7 @@ ENV PYTHONPATH /opt/alv4/assemblyline-base:/opt/alv4/assemblyline-core:/opt/alv4
 RUN apt-get update && apt-get -yy upgrade && rm -rf /var/lib/apt/lists/*
 
 # SSDEEP pkg requirments
-RUN apt-get update && apt-get install -yy build-essential libssl-dev libffi-dev libfuzzy-dev libldap2-dev libsasl2-dev libmagic1 zip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -yy build-essential libssl-dev libffi-dev libfuzzy-dev libldap2-dev libsasl2-dev libmagic1 zip 7zip && rm -rf /var/lib/apt/lists/*
 
 # Python packages requirements
 RUN pip install --no-warn-script-location --no-cache-dir \

--- a/setup.py
+++ b/setup.py
@@ -107,5 +107,8 @@ setup(
             "VERSION",
         ],
         "assemblyline": ["py.typed"]
+    },
+    entry_points= {
+        "console_scripts": ["al_cli=assemblyline.run.cli:shell_main"]
     }
 )


### PR DESCRIPTION
Issues fixed:

- Correct submission profiles to not use the `excluded` field as that can impact use with post-process actions
- Add configuration for external file sources to automatically unpack zip file containing a single file (ie. MalwareBazaaer) before submitting to the system
- Fix cases where the executive summary can crash if a service provides invalid data in the results
- Update import bundle call to support reclassification of data and add configuration to Replay to support data reclassification
- Add a console script to invoke AL's CLI via `al_cli` in an easier manner
- Update bundling testing & logic to account for filtering data based on user classification