### PR TITLE
Update AI default configuration to use top_p: 1 as 0 is invalid

### DIFF
--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -1320,7 +1320,7 @@ regarding Assemblyline. $(EXTRA_CONTEXT)
         "frequency_penalty": 0,
         "presence_penalty": 0,
         "temperature": 0,
-        "top_p": 0
+        "top_p": 1
     }
 }
 
@@ -1347,7 +1347,7 @@ a malware detection and analysis tool. $(EXTRA_CONTEXT)
         "frequency_penalty": 0,
         "presence_penalty": 0,
         "temperature": 0,
-        "top_p": 0
+        "top_p": 1
     }
 }
 
@@ -1376,7 +1376,7 @@ Your role is to extract information of importance and discard what is not. $(EXT
         "frequency_penalty": 0,
         "presence_penalty": 0,
         "temperature": 0,
-        "top_p": 0
+        "top_p": 1
     }
 }
 
@@ -1401,7 +1401,7 @@ report into a one or two paragraph executive summary. DO NOT write any headers i
         "frequency_penalty": 0,
         "presence_penalty": 0,
         "temperature": 0,
-        "top_p": 0
+        "top_p": 1
     }
 }
 


### PR DESCRIPTION
After setting up Assemblyline to integrate with our on premise AI server, we encountered an error where it appears that the default value of top_p is set to 0, which it appears that it is not able to be set to 0 as our AI had returned an error indicating that the value of top_p must be within `(0,1]` indicating that the value must be between 0 and 1 but can not equal 0, but can equal 1.

According to the below reference, it explains how having a value of 0 does not make sense because top_p controls the what tokens are considered and so if top_p is 0.1 then only the top 10% of tokens are considered or if 0.9 then the top 90% of tokens are considered, but having a value of 0 would mean that the top 0% of tokens would be considered, which doesn't make sense.

> https://docs.aipower.org/docs/ai-engine/openai/top-p
>
> ![image](https://github.com/user-attachments/assets/ee7b287d-a5c5-4e1e-b538-26934de37ce4)

I'm not sure what value is good for a sensible default, but setting a value of 1 will lead to more creative responses as the AI will use consider more tokens.

I also noticed issues with the documentation as many of the keys / configuration were not accurate and will submit a separate PR to propose changes there.

Documentation PR - https://github.com/CybercentreCanada/assemblyline4_docs/pull/165
As a note, you can see that the top_p value in the documentation was previously set to 1.