### PR TITLE
Add initial ODM for Mach-O binaries

### DIFF
--- a/assemblyline/odm/models/ontology/file.py
+++ b/assemblyline/odm/models/ontology/file.py
@@ -1,5 +1,5 @@
 from assemblyline import odm
-from assemblyline.odm.models.ontology.filetypes import PE
+from assemblyline.odm.models.ontology.filetypes import PE, MachO
 
 
 @odm.model(description="File Characteristics")
@@ -24,3 +24,4 @@ class File(odm.Model):
     # powershell = odm.Optional(odm.Compound(PowerShell), description="PowerShell File Properties")
     # shortcut = odm.Optional(odm.Compound(Shortcut), description="Shortcut File Properties")
     # swf = odm.Optional(odm.Compound(SWF), description="SWF File Properties")
+    macho = odm.Optional(odm.Compound(MachO), description="Properties related to MachO")

--- a/assemblyline/odm/models/ontology/filetypes/__init__.py
+++ b/assemblyline/odm/models/ontology/filetypes/__init__.py
@@ -1,1 +1,2 @@
 from assemblyline.odm.models.ontology.filetypes.pe import PE
+from assemblyline.odm.models.ontology.filetypes.macho import MachO

--- a/assemblyline/odm/models/ontology/filetypes/macho.py
+++ b/assemblyline/odm/models/ontology/filetypes/macho.py
@@ -75,3 +75,10 @@ class MachO(odm.Model):
         version = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
         entitlement = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
         requirement = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        
+    header = odm.Optional(odm.Compound(Header))
+    segments = odm.Optional(odm.List(odm.Compound(Segments)))
+    sections = odm.Optional(odm.List(odm.Compound(Sections)))
+    libraries = odm.Optional(odm.List(odm.Compound(Libraries)))
+    loadcommands = odm.Optional(odm.List(odm.Compound(LoadCommands)))
+    notarization = odm.Optional(odm.Compound(Notarization))

--- a/assemblyline/odm/models/ontology/filetypes/macho.py
+++ b/assemblyline/odm/models/ontology/filetypes/macho.py
@@ -49,6 +49,7 @@ class MachO(odm.Model):
         reserved1 = odm.Optional(odm.Integer())
         reserved2 = odm.Optional(odm.Integer())
         reserved3 = odm.Optional(odm.Integer())
+        hash = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
 
     @odm.model(index=True, store=False)
     class Libraries(odm.Model):

--- a/assemblyline/odm/models/ontology/filetypes/macho.py
+++ b/assemblyline/odm/models/ontology/filetypes/macho.py
@@ -1,0 +1,76 @@
+from assemblyline import odm
+
+
+@odm.model(index=True, store=False)
+class MachO(odm.Model):
+    @odm.model(index=True, store=False)
+    class Header(odm.Model):
+        entrypoint = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        cpu_type = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        cpu_sub_type = odm.Optional(odm.Integer())
+        file_type = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        flags = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        numberof_loadcommands = odm.Optional(odm.Integer())
+        sizeof_loadcommands = odm.Optional(odm.Integer())
+        minimum_os_version = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        platform = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        sdk_version = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        linker = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        base = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        is_ios = odm.Optional(odm.Boolean())
+        is_macos = odm.Optional(odm.Boolean())
+        is_position_independent = odm.Optional(odm.Boolean())
+        is_norized = odm.Optional(odm.Boolean())
+        uuid = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+
+    @odm.model(index=True, store=False)
+    class Segments(odm.Model):
+        offset = odm.Optional(odm.Integer())
+        size = odm.Optional(odm.Integer())
+        flags = odm.Optional(odm.Integer())
+        index = odm.Optional(odm.Integer())
+        numberof_sections = odm.Optional(odm.Integer())
+        name = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        virtual_address = odm.Optional(odm.Integer())
+        virtual_size = odm.Optional(odm.Integer())
+        initial_protection = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        max_protection = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+
+    @odm.model(index=True, store=False)
+    class Sections(odm.Model):
+        type = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        name = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        flags = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        alignment = odm.Optional(odm.Integer())
+        relocation_offset = odm.Optional(odm.Integer())
+        numberof_relocations = odm.Optional(odm.Integer())
+        entropy = odm.Optional(odm.Float())
+        segment_name = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        reserved1 = odm.Optional(odm.Integer())
+        reserved2 = odm.Optional(odm.Integer())
+        reserved3 = odm.Optional(odm.Integer())
+
+    @odm.model(index=True, store=False)
+    class Libraries(odm.Model):
+        name = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        timestamp = odm.Optional(odm.Integer())
+        compatibility_version = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        current_version = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+
+    @odm.model(index=True, store=False)
+    class LoadCommands(odm.Model):
+        name = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        offset = odm.Optional(odm.Integer())
+        size = odm.Optional(odm.Integer())
+
+    @odm.model(index=True, store=False)
+    class Notarization(odm.Model):
+        flags = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        hash_offset = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        hash_size = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        platform = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        codedir_size = odm.Optional(odm.Integer())
+        identifier_string = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        version = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        entitlement = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))
+        requirement = odm.Optional(odm.EmptyableKeyword(copyto="__text__"))

--- a/assemblyline/odm/models/tagging.py
+++ b/assemblyline/odm/models/tagging.py
@@ -461,6 +461,7 @@ class Tagging(odm.Model):
         img = odm.Optional(odm.Compound(FileIMG), description="Image File Properties")
         ole = odm.Optional(odm.Compound(FileOLE), description="OLE File Properties")
         pe = odm.Optional(odm.Compound(FilePE), description="PE File Properties")
+        macho = odm.Optional(odm.Compound(FileMachO), description="Mach-O File Properties")
         pdf = odm.Optional(odm.Compound(FilePDF), description="PDF File Properties")
         plist = odm.Optional(odm.Compound(FilePList), description="PList File Properties")
         powershell = odm.Optional(odm.Compound(FilePowerShell), description="PowerShell File Properties")

--- a/assemblyline/odm/models/tagging.py
+++ b/assemblyline/odm/models/tagging.py
@@ -367,6 +367,51 @@ class Tagging(odm.Model):
         class FilePowerShell(odm.Model):
             cmdlet = odm.Optional(odm.List(odm.Keyword(copyto="__text__")), description="Cmdlet")
 
+        @odm.model(index=True, store=False, description="Mach-O File Tag Model")
+        class FileMachO(odm.Model):
+            @odm.model(index=True, store=False, description="Mach-O Sections Model")
+            class FileMachOSections(odm.Model):
+                hash = odm.Optional(
+                    odm.List(odm.Keyword(copyto="__text__")), description="Hash"
+                )
+                name = odm.Optional(
+                    odm.List(odm.Keyword(copyto="__text__")), description="Name"
+                )
+
+            @odm.model(index=True, store=False, description="Mach-O Code Signing Model")
+            class FileMachONotarization(odm.Model):
+                identifier_string = odm.Optional(
+                    odm.List(odm.Keyword(copyto="__text__")),
+                    description="Identifier String",
+                )
+                team_id = odm.Optional(
+                    odm.List(odm.Keyword(copyto="__text__")),
+                    description="Team Identifier",
+                )
+
+            @odm.model(index=True, store=False, description="Mach-O Linker Model")
+            class FileMachoLinker(odm.Model):
+                image_uuid = odm.Optional(
+                    odm.List(odm.Keyword(copyto="__text__")), description="Image UUID"
+                )
+                image_platform = odm.Optional(
+                    odm.List(
+                        odm.Keyword(copyto="__text__"), description="Image Platform"
+                    )
+                )
+
+            sections = odm.Optional(
+                odm.Compound(FileMachOSections),
+                description="Mach-O Sections Information",
+            )
+            notarization = odm.Optional(
+                odm.Compound(FileMachONotarization),
+                description="Mach-O Notarization Information",
+            )
+            linker = odm.Optional(
+                odm.Compound(FileMachoLinker), description="Mach-O Linker Information"
+            )
+
         @odm.model(index=True, store=False, description="Shortcut File Tag Model")
         class FileShortcut(odm.Model):
             command_line = odm.Optional(odm.List(odm.Keyword(copyto="__text__")), description="Command Line")


### PR DESCRIPTION
This PR adds the initial ODM for Mach-O binaries to be used by services which wish to add tagging for Mach-O binaries. The service this is meant for is currently still in development with release TBD hopefully soon. 

Feedback is welcomed!