### PR TITLE
Add config for openid connect url

### DIFF
--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -247,7 +247,7 @@ class OAuthProvider(odm.Model):
     validate_token_with_secret: bool = odm.Boolean(
         default=False, description="Should we send the client secret while validating the access token?")
     identity_id_field: str = odm.Keyword(default='oid', description="Field to fetch the managed identity ID from.")
-    openid_connect_url: str = odm.Optional(
+    openid_connect_discovery_url: str = odm.Optional(
         odm.Keyword(), description="URL for connecting to the OpenID configuration JSON."
     )
     groups_id_token_field: str = odm.Keyword(


### PR DESCRIPTION
- Add new fields to add to OAuth configuration to use [open id connect url](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest) to get connection url to variable resources.

- Add a map that maps the corresponding user_info fields to open_id json keys.
For https://github.com/CybercentreCanada/assemblyline/issues/364 