### PR TITLE
Remove indicators causing code/c fpos in identify

### DIFF
--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -729,8 +729,7 @@ rule code_c {
         $ = /(^|\n)#include[ \t]*([<"])[\w.\/]+([>"])/
         $ = /(^|\n)#(if !defined|ifndef|define|endif|pragma)[ \t]+/
         $ = /(^|\n)public[ \t]*:/
-        $ = /ULONG|HRESULT|STDMETHOD/
-        $ = "THIS"
+        $ = /ULONG|STDMETHOD/
         $ = /(^|\n)(const[ \t]+char[ \t]+\w+;|extern[ \t]+|uint(8|16|32)_t[ \t]+)/
 
     condition:


### PR DESCRIPTION
HRESULT and THIS appear in PE string data.