### PR TITLE
Updating dev setup for 4.7+

### DIFF
--- a/dev/core/config/config.yml
+++ b/dev/core/config/config.yml
@@ -8,9 +8,11 @@ core:
       hosts: [http://elastic:devpass@elasticsearch:9200]
     redis:
       host: redis
+      port: 6379
   redis:
     nonpersistent:
       host: redis
+      port: 6379
     persistent:
       host: redis
       port: 6379

--- a/dev/core/docker-compose.yml
+++ b/dev/core/docker-compose.yml
@@ -3,23 +3,21 @@ version: "2.4"
 services:
   # Service server
   al_service_server:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline-rust:4.7.latest
     env_file:
       - .env
     ports:
       - "5003:5003"
     volumes:
       - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
-      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
-    working_dir: /opt/alv4/
-    command: python3 /opt/alv4/assemblyline-service-server/assemblyline_service_server/app.py
+    command: assemblyline-server service-api --allow-http-mode
     networks:
       - default
       - registration
 
   # Create test data
   create_test_data:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline_dev:4.7.1
     env_file:
       - .env
     environment:
@@ -45,7 +43,7 @@ services:
 
   # UI
   al_ui:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline_dev:4.7.1
     env_file:
       - .env
     ports:
@@ -58,7 +56,7 @@ services:
 
   # SocketIO Server
   al_socketio:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline_dev:4.7.1
     env_file:
       - .env
     ports:
@@ -71,7 +69,7 @@ services:
 
   # Alerter
   al_alerter:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline_dev:4.7.1
     env_file:
       - .env
     volumes:
@@ -89,7 +87,7 @@ services:
 
   # Alerter
   al_archiver:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline_dev:4.7.1
     env_file:
       - .env
     volumes:
@@ -107,7 +105,7 @@ services:
 
   # Expiry
   al_expiry:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline_dev:4.7.1
     env_file:
       - .env
     volumes:
@@ -125,7 +123,7 @@ services:
 
   # Elasticsearch Metrics
   al_elastic_metrics:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline_dev:4.7.1
     env_file:
       - .env
     volumes:
@@ -143,7 +141,7 @@ services:
 
   # Metrics aggregator
   al_metrics:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline_dev:4.7.1
     env_file:
       - .env
     volumes:
@@ -153,7 +151,7 @@ services:
 
   # Hearbeat manager
   al_heartbeat:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline_dev:4.7.1
     env_file:
       - .env
     volumes:
@@ -171,7 +169,7 @@ services:
 
   # Stats aggregator
   al_stats:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline_dev:4.7.1
     env_file:
       - .env
     volumes:
@@ -181,7 +179,7 @@ services:
 
   # Workflow
   al_workflow:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline_dev:4.7.1
     env_file:
       - .env
     volumes:
@@ -198,59 +196,32 @@ services:
         ]
 
   al_plumber:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline-rust:4.7.latest
     env_file:
       - .env
     volumes:
       - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
-      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
-    command: python3 /opt/alv4/assemblyline-core/assemblyline_core/plumber/run_plumber.py
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "bash",
-          "-c",
-          "if [[ ! `find /tmp/heartbeat -newermt '-30 seconds'` ]]; then false; fi",
-        ]
+    command: assemblyline-server plumber
 
   # Dispatcher processes
   al_dispatcher:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline-rust:4.7.latest
     env_file:
       - .env
     volumes:
       - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
-      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
     environment:
       SKIP_SERVICE_SETUP: "true"
-    command: python3 /opt/alv4/assemblyline-core/assemblyline_core/dispatching
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "bash",
-          "-c",
-          "if [[ ! `find /tmp/heartbeat -newermt '-30 seconds'` ]]; then false; fi",
-        ]
+    command: assemblyline-server dispatcher
 
   # Ingester Processes
   al_ingester:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline-rust:4.7.latest
     env_file:
       - .env
     volumes:
       - ${PATH_REWRITE:-.}/config/:/etc/assemblyline/
-      - ${ROOT_REWRITE:-../../..}/:/opt/alv4/
-    command: python3 /opt/alv4/assemblyline-core/assemblyline_core/ingester
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "bash",
-          "-c",
-          "if [[ ! `find /tmp/heartbeat -newermt '-30 seconds'` ]]; then false; fi",
-        ]
+    command: assemblyline-server ingester
 
 # You can use this if you want a jupyter notebook to debug something in development
 #  notebook:

--- a/docker/al_dev/Dockerfile
+++ b/docker/al_dev/Dockerfile
@@ -1,26 +1,28 @@
 FROM python:3.11-slim-bookworm
 
 # Setup environment varibles
-ENV PYTHONPATH /opt/alv4/assemblyline-base:/opt/alv4/assemblyline-core:/opt/alv4/assemblyline-service-server:/opt/alv4/assemblyline-service-client:/opt/alv4/assemblyline_client:/opt/alv4/assemblyline-ui
+ENV PYTHONPATH /opt/alv4/assemblyline-base:/opt/alv4/assemblyline-core:/opt/alv4/assemblyline-service-client:/opt/alv4/assemblyline_client:/opt/alv4/assemblyline-ui
 
 # Upgrade packages
 RUN apt-get update && apt-get -yy upgrade && rm -rf /var/lib/apt/lists/*
 
-# SSDEEP pkg requirments
-RUN apt-get update && apt-get install -yy build-essential libssl-dev libffi-dev libfuzzy-dev libldap2-dev libsasl2-dev libmagic1 zip 7zip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -yy \
+    # python-ldap dependencies
+    build-essential libldap2-dev libsasl2-dev \
+    libssl-dev libmagic1 zip 7zip && \
+    rm -rf /var/lib/apt/lists/*
 
 # Python packages requirements
 RUN pip install --no-warn-script-location --no-cache-dir \
    assemblyline[test] \
    assemblyline-core \
    assemblyline-ui \
-   assemblyline-service-server \
    debugpy \
    && pip uninstall -y \
    assemblyline \
    assemblyline-core \
    assemblyline-ui \
-   assemblyline-service-server \
    && rm -rf ~/.cache/pip
 
 

--- a/docker/al_dev/Dockerfile
+++ b/docker/al_dev/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
 RUN pip install --no-warn-script-location --no-cache-dir \
    assemblyline[test] \
    assemblyline-core \
-   assemblyline-ui \
+   assemblyline-ui[socketio] \
    debugpy \
    && pip uninstall -y \
    assemblyline \

--- a/docker/build_containers.sh
+++ b/docker/build_containers.sh
@@ -6,5 +6,5 @@
 (cd minio && docker build -t cccs/minio .)
 
 # Build default dev containers
-(cd ../.. && docker build --no-cache -f assemblyline-base/docker/al_dev/Dockerfile -t cccs/assemblyline_dev:latest -t cccs/assemblyline_dev:4.6.1 .)
-(cd ../.. && docker build --no-cache -f assemblyline-base/docker/al_management/Dockerfile -t cccs/assemblyline_management:latest -t cccs/assemblyline_management:4.6.1 .)
+(cd ../.. && docker build --no-cache -f assemblyline-base/docker/al_dev/Dockerfile -t cccs/assemblyline_dev:latest -t cccs/assemblyline_dev:4.7.1 .)
+(cd ../.. && docker build --no-cache -f assemblyline-base/docker/al_management/Dockerfile -t cccs/assemblyline_management:latest -t cccs/assemblyline_management:4.7.1 .)

--- a/docker/nginx-ssl-frontend/Dockerfile
+++ b/docker/nginx-ssl-frontend/Dockerfile
@@ -1,7 +1,7 @@
 FROM nginx AS builder
 
 RUN apt-get update
-RUN apt-get install openssl
+RUN apt-get install -y openssl
 RUN openssl req -nodes -x509 -newkey rsa:4096 -keyout /etc/ssl/nginx.key -out /etc/ssl/nginx.crt -days 3650 -subj "/C=CA/ST=Ontario/L=Ottawa/O=CCCS/CN=assemblyline.local"
 
 FROM nginx

--- a/docker/nginx-ssl-frontend:mui5/Dockerfile
+++ b/docker/nginx-ssl-frontend:mui5/Dockerfile
@@ -1,7 +1,7 @@
 FROM nginx AS builder
 
 RUN apt-get update
-RUN apt-get install openssl
+RUN apt-get install -y openssl
 RUN openssl req -nodes -x509 -newkey rsa:4096 -keyout /etc/ssl/nginx.key -out /etc/ssl/nginx.crt -days 3650 -subj "/C=CA/ST=Ontario/L=Ottawa/O=CCCS/CN=assemblyline.local"
 
 FROM nginx


### PR DESCRIPTION
A new build of the dev container will be needed, and preferably named 4.7.1 to fit this change.
Almost everything else was back to a functional state, beside socketio giving the following error:
```
Traceback (most recent call last):
  File "/opt/alv4/assemblyline-ui/assemblyline_ui/socketsrv.py", line 12, in <module>
    from flask_socketio import SocketIO
ModuleNotFoundError: No module named 'flask_socketio'
```
I'm assuming we need to add flask_socketio to the assemblyline-ui [install_requires](https://github.com/CybercentreCanada/assemblyline-ui/blob/master/setup.py#L41).