### PR TITLE
Added YARA signature for MSBuild script files.

### DIFF
--- a/assemblyline/common/custom.magic
+++ b/assemblyline/common/custom.magic
@@ -24,6 +24,10 @@
 # Open XML files with Microsoft Word
 0   string
 >0  search/0x100 =<?mso-application\ progid="Word.Document"?>    custom: document/office/word
+# MSBuild Project Files
+0      string
+>0     search/0x40    \<Project
+>>&0   search/0x40    http://schemas.microsoft.com/developer/msbuild    custom: code/xml/msbuild
 # VBE files
 0 string #@~^
 >&0 regex/9 \^[^=]{6}== custom: code/vbe

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -1526,7 +1526,7 @@ MSBuild Script Files (Project files for VB, C#, F# etc)
 
 rule code_msbuild {
     meta:
-        type = "code/msbuild"
+        type = "code/xml/msbuild"
 
     strings:
         $msbuild1 = "<Project"

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -1519,3 +1519,20 @@ rule text_rdp {
         // Add two optionals, to reduce false positives.
         and 2 of ($optional*)
 }
+
+/*
+MSBuild Script Files (Project files for VB, C#, F# etc)
+*/
+
+rule code_msbuild {
+    meta:
+        type = "code/msbuild"
+
+    strings:
+        $msbuild1 = "<Project"
+        $xmlns_url = "http://schemas.microsoft.com/developer/msbuild"
+
+    condition:
+        $msbuild1
+        and $xmlns_url in (0..256)
+}

--- a/assemblyline/common/custom.yara
+++ b/assemblyline/common/custom.yara
@@ -1519,20 +1519,3 @@ rule text_rdp {
         // Add two optionals, to reduce false positives.
         and 2 of ($optional*)
 }
-
-/*
-MSBuild Script Files (Project files for VB, C#, F# etc)
-*/
-
-rule code_msbuild {
-    meta:
-        type = "code/xml/msbuild"
-
-    strings:
-        $msbuild1 = "<Project"
-        $xmlns_url = "http://schemas.microsoft.com/developer/msbuild"
-
-    condition:
-        $msbuild1
-        and $xmlns_url in (0..256)
-}


### PR DESCRIPTION
This  adds identification for MSBuild script files. These can be important for identify supply-chain attacks or exploitation of build systems to deliver malicious payloads.

I used this XML rule as a template: https://github.com/CybercentreCanada/assemblyline-base/blob/7d51392f29213082ccb86715fc13cec27d618145/assemblyline/common/custom.yara#L133