### PR TITLE
Add dotdump_utf8 helper for UTF-8-aware file viewer rendering

### DIFF
--- a/assemblyline/common/str_utils.py
+++ b/assemblyline/common/str_utils.py
@@ -124,6 +124,30 @@ def dotdump(s):
     return ''.join(['.' if x < 32 or x > 126 else chr(x) for x in s])
 
 
+def dotdump_utf8(s: Union[str, bytes]) -> str:
+    """Like dotdump, but preserves valid UTF-8 multi-byte characters.
+
+    Bytes that form a valid UTF-8 sequence representing a printable character
+    (or tab/LF/CR) are kept as their decoded code point. Every other byte
+    (control bytes, lone continuation bytes, overlong/invalid sequences) is
+    replaced with a single '.' so the output length matches the input in
+    bytes for the invalid sections.
+    """
+    if isinstance(s, str):
+        s = s.encode('utf-8', errors='surrogateescape')
+
+    out = []
+    # _valid_utf8.split returns alternating non-matching/matching segments.
+    # Odd indices are the captured valid UTF-8 segments; even indices are
+    # the bytes that did not match (i.e. invalid or non-printable bytes).
+    for i, part in enumerate(_valid_utf8.split(s)):
+        if i % 2:
+            out.append(part.decode('utf-8'))
+        else:
+            out.append('.' * len(part))
+    return ''.join(out)
+
+
 def escape_str(s, reversible=True, force_str=False) -> str:
     if isinstance(s, bytes):
         return escape_str_strict(s, reversible)


### PR DESCRIPTION
## Summary

Adds `dotdump_utf8()` to `assemblyline.common.str_utils` — a UTF-8-aware
counterpart to the existing `dotdump()` helper. Valid UTF-8 multi-byte
sequences (accented Latin, CJK, emoji, etc.) are preserved as their decoded
characters; only invalid or non-printable bytes are replaced with `.`.

This is the supporting library change for an upcoming
`assemblyline-ui` PR that switches the **File Viewer** ASCII tab to render
UTF-8 instead of dot-replacing every non-ASCII byte.

## Why

The current File Viewer applies `bytes.translate(FILTER_ASCII)`, which maps
every byte outside printable ASCII (32–126, plus tab/LF/CR) to `.`. Because
every byte of a UTF-8 multi-byte sequence is in the `0x80–0xFF` range,
files containing `café`, `日本語`, `🎉`, etc. are rendered as solid dots.

## Implementation

- Reuses the existing `_valid_utf8` regex (RFC 3629, already used by
  `escape_str_strict`) so the definition of "valid UTF-8" stays consistent
  across the codebase.
- `_valid_utf8.split(s)` returns alternating non-matching / captured
  segments. Captured (valid UTF-8) segments are decoded to `str`;
  non-matching bytes are replaced one-for-one with `.`, preserving the
  byte length of invalid sections.

## Behaviour

| Input | Output |
|---|---|
| `b'hello\nworld'` | `'hello\nworld'` |
| `'café'.encode()` | `'café'` |
| `'日本語'.encode()` | `'日本語'` |
| `'🎉ok'.encode()` | `'🎉ok'` |
| `b'A\x00B\x07C'` | `'A.B.C'` |
| `b'\xc3('` (bad 2-byte start) | `'.('` |
| `b'\xed\xa0\x80'` (UTF-16 surrogate) | `'...'` |
| `b'\t\r\n abc'` | `'\t\r\n abc'` |

## Risk

- New, additive helper. No existing call sites are changed in this PR.
- No new dependencies; reuses the existing compiled `_valid_utf8` regex.
