### PR TITLE
Add testing for IRSA using an AWS emulator

### DIFF
--- a/assemblyline/filestore/__init__.py
+++ b/assemblyline/filestore/__init__.py
@@ -128,7 +128,7 @@ def create_transport(url, connection_attempts=None):
 
     elif scheme == 's3':
         valid_str_keys = ['aws_region', 's3_bucket']
-        valid_bool_keys = ['use_ssl', 'verify', 'boto_defaults', 'read_only']
+        valid_bool_keys = ['use_ssl', 'verify', 'boto_defaults', 'read_only', 'debug']
         extras = _get_extras(parse_qs(parsed.query), valid_str_keys=valid_str_keys, valid_bool_keys=valid_bool_keys)
 
         # If user/password not specified, access might be dictated by IAM roles

--- a/assemblyline/filestore/transport/s3.py
+++ b/assemblyline/filestore/transport/s3.py
@@ -35,7 +35,7 @@ class TransportS3(Transport):
     DEFAULT_HOST = "s3.amazonaws.com"
 
     def __init__(self, base=None, accesskey=None, secretkey=None, aws_region=None, s3_bucket="al-storage",
-                 host=None, port=None, use_ssl=None, verify=True, connection_attempts=None, boto_defaults=False, read_only=False):
+                 host=None, port=None, use_ssl=None, verify=True, connection_attempts=None, boto_defaults=False, read_only=False, debug=False):
         self.log = logging.getLogger('assemblyline.transport.s3')
         self.base = base
         self.bucket = s3_bucket
@@ -80,6 +80,17 @@ class TransportS3(Transport):
                     use_ssl=self.use_ssl,
                     verify=verify,
                 )
+
+        # Log the credential provider being when debugging is enabled for the transport
+        if debug:
+            credentials = self.client._get_credentials()
+            self.log.debug(f"Credential provider for '{self.endpoint_url}': method: {credentials.method}, "
+                           f"account_id: {credentials.account_id}, "
+                           f"access_key: {credentials.access_key}, "
+                           f"secret_key: { 'set' if credentials.secret_key else 'not set' }"
+                           f"token: { 'set' if credentials.token else 'not set' }")
+
+
 
         bucket_exist = False
         try:

--- a/pipelines/azure-tests.yaml
+++ b/pipelines/azure-tests.yaml
@@ -51,6 +51,12 @@ resources:
         MINIO_ROOT_PASSWORD: Ch@ngeTh!sPa33w0rd
       ports:
         - 9000:9000
+    - container: floci
+      image: floci/floci
+      env:
+        FLOCI_SERVICES_IAM_ENFORCEMENT_ENABLED: "true"
+      ports:
+        - 4566:4566
 
 jobs:
   - job: run_test

--- a/pipelines/azure-tests.yaml
+++ b/pipelines/azure-tests.yaml
@@ -81,6 +81,7 @@ jobs:
       sftp: sftp
       redis: redis
       minio: minio
+      floci: floci
 
     steps:
       - checkout: self

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -12,6 +12,13 @@ services:
     ports:
       - "2222:2222"
 
+  floci:
+    image: floci/floci
+    environment:
+      - FLOCI_SERVICES_IAM_ENFORCEMENT_ENABLED=true
+    ports:
+      - "4566:4566"
+
   minio:
     image: minio/minio
     environment:

--- a/test/test_filestore.py
+++ b/test/test_filestore.py
@@ -178,7 +178,7 @@ def test_s3_aws():
 
     # Setup the IAM role policy for the S3 bucket in emulated AWS environment (e.g., floci)
     os.environ['AWS_ENDPOINT_URL'] = 'http://localhost:4566'
-    os.environ['AWS_REGION'] = 'us-east-1'
+    os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
     s = Session()
     iam_client = s.client('iam', aws_access_key_id="test", aws_secret_access_key="test", use_ssl=False)
     try:
@@ -212,7 +212,7 @@ def test_s3_aws():
     del os.environ['AWS_ENDPOINT_URL']
     del os.environ['AWS_ROLE_ARN']
     del os.environ['AWS_WEB_IDENTITY_TOKEN_FILE']
-    del os.environ['AWS_REGION']
+    del os.environ['AWS_DEFAULT_REGION']
     os.remove(token_file_path)
 
 

--- a/test/test_filestore.py
+++ b/test/test_filestore.py
@@ -4,9 +4,8 @@ import threading
 import traceback
 
 import pytest
-
-from assemblyline.filestore.transport.base import TransportException
 from assemblyline.filestore import FileStore
+from assemblyline.filestore.transport.base import TransportException
 
 _temp_body_a = b'temporary file string'
 
@@ -166,6 +165,54 @@ def test_s3():
     assert fs.get('al4_minio_pytest.txt') == content
     assert fs.delete('al4_minio_pytest.txt') is None
     common_actions(fs)
+
+def test_s3_aws():
+    """
+    Test S3 FileStore using simulated AWS S3 by pushing and fetching back content from it.
+    """
+    from base64 import b64encode
+
+    from boto3.session import Session
+
+    content = b"THIS IS AN AWS S3 TEST"
+
+    # Setup the IAM role policy for the S3 bucket in emulated AWS environment (e.g., floci)
+    os.environ['AWS_ENDPOINT_URL'] = 'http://localhost:4566'
+    s = Session()
+    iam_client = s.client('iam', aws_access_key_id="test", aws_secret_access_key="test", use_ssl=False)
+    try:
+        iam_client.create_role(RoleName="MockedIRSARole", AssumeRolePolicyDocument='{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Principal": {"Federated": "arn:aws:iam::000000000000:oidc-provider/localhost:4566"}, "Action": "sts:AssumeRoleWithWebIdentity"}]}')
+    except iam_client.exceptions.EntityAlreadyExistsException:
+        pass  # Role already exists, which is fine for our test setup
+    iam_client.put_role_policy(RoleName="MockedIRSARole", PolicyName="S3Access", PolicyDocument='{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": ["s3:CreateBucket", "s3:DeleteObject", "s3:GetObject", "s3:PutObject", "s3:ListBucket"], "Resource": ["arn:aws:s3:::al-storage", "arn:aws:s3:::al-storage/*"]}]}')
+
+    # Create a web identity token to cover IRSA authentication flow
+    with tempfile.NamedTemporaryFile(delete=False) as token_file:
+        header = '{"alg": "HS256", "typ": "JWT"}'
+        payload = '{"iss":"http://localhost:4566","sub":"system:serviceaccount:default:assemblyline","aud":["://amazonaws.com"],"exp":2082758400}'
+        token = b64encode(header.encode()) + b'.' + b64encode(payload.encode()) + b'.test_signature'
+        token_file.write(token)
+        token_file_path = token_file.name
+
+    # Set environment variables to simulate IRSA authentication for the AWS S3 FileStore
+    os.environ['AWS_ROLE_ARN'] = 'arn:aws:iam::000000000000:role/MockedIRSARole'
+    os.environ['AWS_WEB_IDENTITY_TOKEN_FILE'] = token_file_path
+
+    fs = FileStore('s3://localhost:4566/?use_ssl=False')
+
+    # Based on the policy, our client should have the necessary permissions to perform the following operations similar to the Minio test, but now against the AWS S3 emulation:
+    assert fs.put('al4_aws_s3_pytest.txt', content) != []
+    assert fs.exists('al4_aws_s3_pytest.txt') != []
+    assert fs.get('al4_aws_s3_pytest.txt') == content
+    assert fs.delete('al4_aws_s3_pytest.txt') is None
+    common_actions(fs)
+
+    # Cleanup the environment variables and temporary token file to ensure they don't interfere with other tests
+    del os.environ['AWS_ENDPOINT_URL']
+    del os.environ['AWS_ROLE_ARN']
+    del os.environ['AWS_WEB_IDENTITY_TOKEN_FILE']
+    os.remove(token_file_path)
+
 
 
 def common_actions(fs, check_listing=True):

--- a/test/test_filestore.py
+++ b/test/test_filestore.py
@@ -178,6 +178,7 @@ def test_s3_aws():
 
     # Setup the IAM role policy for the S3 bucket in emulated AWS environment (e.g., floci)
     os.environ['AWS_ENDPOINT_URL'] = 'http://localhost:4566'
+    os.environ['AWS_REGION'] = 'us-east-1'
     s = Session()
     iam_client = s.client('iam', aws_access_key_id="test", aws_secret_access_key="test", use_ssl=False)
     try:
@@ -211,6 +212,7 @@ def test_s3_aws():
     del os.environ['AWS_ENDPOINT_URL']
     del os.environ['AWS_ROLE_ARN']
     del os.environ['AWS_WEB_IDENTITY_TOKEN_FILE']
+    del os.environ['AWS_REGION']
     os.remove(token_file_path)
 
 


### PR DESCRIPTION
Uses https://github.com/floci-io/floci to emulate a connection to S3 storage hosted by AWS
- Adds testing for [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) for EKS deployments of Assemblyline