### PR TITLE
Revert "Assemblyline/issues/445 (dev)"

### DIFF
--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -3,10 +3,7 @@ from typing import Any, Dict, List
 from assemblyline import odm
 from assemblyline.common.constants import PRIORITIES
 from assemblyline.common.forge import get_classification
-from assemblyline.odm.models.service import (
-    SUPPORTED_REGISTRY_TYPES,
-    EnvironmentVariable,
-)
+from assemblyline.odm.models.service import EnvironmentVariable
 from assemblyline.odm.models.service_delta import DockerConfigDelta
 from assemblyline.odm.models.submission import DEFAULT_SRV_SEL, ServiceSelection
 
@@ -1187,6 +1184,7 @@ SERVICE_STAGES = [
 ]
 
 SAFELIST_HASH_TYPES = ['sha1', 'sha256', 'md5']
+REGISTRY_TYPES = ['docker', 'harbor']
 
 
 @odm.model(index=False, store=False, description="Service's Safelisting Configuration")
@@ -1203,7 +1201,7 @@ class ServiceSafelist(odm.Model):
 @odm.model(index=False, store=False, description="Pre-Configured Registry Details for Services")
 class ServiceRegistry(odm.Model):
     name: str = odm.Keyword(description="Name of container registry")
-    type: str = odm.Enum(values=SUPPORTED_REGISTRY_TYPES, default='docker', description="Type of container registry")
+    type: str = odm.Enum(values=REGISTRY_TYPES, default='docker', description="Type of container registry")
     username: str = odm.Optional(odm.Keyword(description="Username for container registry"))
     password: str = odm.Optional(odm.Keyword(description="Password for container registry"))
     use_fic: bool = odm.Boolean(
@@ -1227,7 +1225,7 @@ class Services(odm.Model):
     allow_insecure_registry: bool = odm.Boolean(description="Allow fetching container images from insecure registries")
 
     preferred_registry_type: str = odm.Enum(
-        values=SUPPORTED_REGISTRY_TYPES,
+        values=REGISTRY_TYPES,
         default='docker',
         description="Global registry type to be used for fetching updates for a service (overridable by a service)")
     prefer_service_privileged: bool = odm.Boolean(

--- a/assemblyline/odm/models/service.py
+++ b/assemblyline/odm/models/service.py
@@ -12,7 +12,6 @@ from assemblyline.common.constants import (
 Classification = forge.get_classification()
 
 FETCH_METHODS = ["GET", "POST", "GIT"]
-SUPPORTED_REGISTRY_TYPES = ["docker", "harbor", "jfrog"]
 
 SIGNATURE_DELIMITERS = {
     'new_line': '\n',
@@ -45,7 +44,7 @@ class DockerConfig(odm.Model):
                                                description="The username to use when pulling the image")
     registry_password: Opt[str] = odm.Optional(odm.Keyword(default=""),
                                                description="The password or token to use when pulling the image")
-    registry_type: str = odm.Enum(values=SUPPORTED_REGISTRY_TYPES, default='docker',
+    registry_type: str = odm.Enum(values=["docker", "harbor"], default='docker',
                                   description="The type of container registry")
     ports: list[str] = odm.List(odm.Keyword(), default=[], description="What ports of container to expose?")
     ram_mb: int = odm.Integer(default=512, description="Container RAM limit")

--- a/assemblyline/odm/models/service_delta.py
+++ b/assemblyline/odm/models/service_delta.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
 from assemblyline import odm
-from assemblyline.odm.models.service import (
-    FETCH_METHODS,
-    SIGNATURE_DELIMITERS,
-    SUPPORTED_REGISTRY_TYPES,
-)
+from assemblyline.odm.models.service import FETCH_METHODS, SIGNATURE_DELIMITERS
 
 REF_DEPENDENCY_CONFIG = "Refer to:<br>[Service - DependencyConfig](../service/#dependencyconfig)"
 REF_DOCKER_CONFIG = "Refer to:<br>[Service - DockerConfig](../service/#dockerconfig)"
@@ -32,7 +28,7 @@ class DockerConfigDelta(odm.Model):
     image = odm.Optional(odm.Keyword(), description=REF_DOCKER_CONFIG)
     registry_username = odm.Optional(odm.Keyword(default=""), description=REF_DOCKER_CONFIG)
     registry_password = odm.Optional(odm.Keyword(default=""), description=REF_DOCKER_CONFIG)
-    registry_type = odm.Optional(odm.Enum(values=SUPPORTED_REGISTRY_TYPES), description=REF_DOCKER_CONFIG)
+    registry_type = odm.Optional(odm.Enum(values=["docker", "harbor"]), description=REF_DOCKER_CONFIG)
     ports = odm.Optional(odm.List(odm.Keyword()), description=REF_DOCKER_CONFIG)
     ram_mb = odm.Optional(odm.Integer(), description=REF_DOCKER_CONFIG)
     ram_mb_min = odm.Optional(odm.Integer(), description=REF_DOCKER_CONFIG)


### PR DESCRIPTION
Reverts CybercentreCanada/assemblyline-base#2132

Reverting changes since the change is no longer necessary since JFrog registries supports [Docker Registry HTTP API V2](https://distribution.github.io/distribution/spec/api/) so the `docker` registry type can be used in AL:
https://discord.com/channels/908084610158714900/909869835041787924/1513910826455666938