### PR TITLE
Regex note

### DIFF
--- a/assemblyline/odm/base.py
+++ b/assemblyline/odm/base.py
@@ -65,7 +65,7 @@ IP_REGEX = f"(?:{IPV4_REGEX}|{IPV6_REGEX})"
 IP_ONLY_REGEX = f"^{IP_REGEX}$"
 IPV4_ONLY_REGEX = f"^{IPV4_REGEX}$"
 IPV6_ONLY_REGEX = f"^{IPV6_REGEX}$"
-PORT_REGEX = r"(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])"
+PORT_REGEX = r"(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])" # produce two matches containing respectively the first 4 digits and one with the last one on 5 digits port numbers, but work as expected for regular group or as a subregex.
 PRIVATE_IP = r"(?:(?:127|10)(?:\.(?:[2](?:[0-5][0-5]|[01234][6-9])|[1][0-9][0-9]|[1-9][0-9]|[0-9])){3})|" \
              r"(?:172\.(?:1[6-9]|2[0-9]|3[0-1])(?:\.(?:2[0-4][0-9]|25[0-5]|[1][0-9][0-9]|[1-9][0-9]|[0-9])){2}|" \
              r"(?:192\.168(?:\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])){2}))"


### PR DESCRIPTION
https://regex101.com/?regex=%280%7C%5B1-9%5D%5B0-9%5D%7B0%2C3%7D%7C%5B1-5%5D%5B0-9%5D%7B4%7D%7C6%5B0-4%5D%5B0-9%5D%7B3%7D%7C65%5B0-4%5D%5B0-9%5D%7B2%7D%7C655%5B0-2%5D%5B0-9%5D%7C6553%5B0-5%5D%29&testString=65000%0A&flags=gmu&flavor=python&delimiter=%22 

The idea is to document this so another mistake doesn't happen inside another service which would like to leverage this regex for individual ports.