### PR TITLE
Add OpenSearch datastore support

### DIFF
--- a/assemblyline/common/forge.py
+++ b/assemblyline/common/forge.py
@@ -132,9 +132,12 @@ def get_datastore(config=None, archive_access=False):
 
     return AssemblylineDatastore(
         ESStore(
-            config.datastore.hosts, archive_access=archive_access,
-            archive_alernate_dtl=config.core.archiver.alternate_dtl))
-
+            config.datastore.hosts,
+            backend=config.datastore.type,
+            archive_access=archive_access,
+            archive_alernate_dtl=config.core.archiver.alternate_dtl,
+        )
+    )
 
 def get_cachestore(component, config=None, datastore=None):
     from assemblyline.cachestore import CacheStore

--- a/assemblyline/datastore/collection.py
+++ b/assemblyline/datastore/collection.py
@@ -22,6 +22,7 @@ from assemblyline import odm
 from assemblyline.common.dict_utils import recursive_update
 from assemblyline.common.isotime import now_as_iso
 from assemblyline.datastore.bulk import ElasticBulkPlan
+from assemblyline.datastore.compat import SearchBackendException
 from assemblyline.datastore.exceptions import (
     ArchiveDisabled,
     DataStoreException,
@@ -327,6 +328,14 @@ class ESCollection(Generic[ModelType]):
         while True:
             try:
                 return self.datastore.with_retries(func, *args, **kwargs)
+            except SearchBackendException as e:
+                if e.status_code == 404 and "index_not_found_exception" in e.message:
+                    time.sleep(min(retries, self.MAX_RETRY_BACKOFF))
+                    log.debug("The index does not exist. Trying to recreate it...")
+                    self._ensure_collection()
+                    retries += 1
+                else:
+                    raise
             except elasticsearch.exceptions.NotFoundError as e:
                 if "index_not_found_exception" in str(e):
                     time.sleep(min(retries, self.MAX_RETRY_BACKOFF))
@@ -968,6 +977,10 @@ class ESCollection(Generic[ModelType]):
                     if version:
                         return self._normalize_output(doc['_source']), f"{doc['_seq_no']}---{doc['_primary_term']}"
                     return self._normalize_output(doc['_source'])
+                except SearchBackendException as err:
+                    if err.status_code != 404:
+                        raise
+                    pass
                 except elasticsearch.exceptions.NotFoundError:
                     pass
 
@@ -1137,6 +1150,10 @@ class ESCollection(Generic[ModelType]):
             try:
                 info = self.with_retries(self.datastore.client.delete, id=key, index=index)
                 deleted |= info['result'] == 'deleted'
+            except SearchBackendException as err:
+                if err.status_code != 404:
+                    raise
+                deleted = True
             except elasticsearch.NotFoundError:
                 deleted = True
 
@@ -1325,6 +1342,10 @@ class ESCollection(Generic[ModelType]):
                 res = self.with_retries(self.datastore.client.update, index=index, id=key,
                                         script=script, retry_on_conflict=retry_on_conflict)
                 return res['result'] == "updated"
+            except SearchBackendException as err:
+                if err.status_code != 404:
+                    raise
+                pass
             except elasticsearch.NotFoundError:
                 pass
             except Exception:
@@ -1606,6 +1627,9 @@ class ESCollection(Generic[ModelType]):
                                            track_total_hits=track_total_hits, **query_body)
 
             return result
+
+        except SearchBackendException as e:
+            raise SearchException(e.message)
 
         except (elasticsearch.TransportError, elasticsearch.RequestError) as e:
             try:
@@ -2170,6 +2194,10 @@ class ESCollection(Generic[ModelType]):
                     self.with_retries(self.datastore.client.indices.create, index=index,
                                       mappings=self._get_index_mappings(),
                                       settings=self._get_index_settings(archive=self.is_archive_index(index)))
+                except SearchBackendException as e:
+                    if "resource_already_exists_exception" not in e.message:
+                        raise
+                    log.warning("Tried to create an index template that already exists: %s", alias.upper())
                 except elasticsearch.exceptions.RequestError as e:
                     if "resource_already_exists_exception" not in str(e):
                         raise

--- a/assemblyline/datastore/compat.py
+++ b/assemblyline/datastore/compat.py
@@ -26,6 +26,10 @@ class UnsupportedSearchBackendOperation(NotImplementedError):
     pass
 
 
+class SearchBackendCompatibilityError(UnsupportedSearchBackendOperation):
+    pass
+
+
 def _load_opensearch_client():
     try:
         from opensearchpy import OpenSearch
@@ -215,14 +219,14 @@ class SearchClientAdapter:
 
     def search(self, **kwargs):
         if self.backend == SearchBackend.OPENSEARCH:
-            if "pit" in kwargs or "search_after" in kwargs:
-                raise UnsupportedSearchBackendOperation("OpenSearch PIT search is not supported by this adapter slice")
             body_keys = {
                 "aggregations",
                 "collapse",
                 "from_",
+                "pit",
                 "query",
                 "script_fields",
+                "search_after",
                 "seq_no_primary_term",
                 "size",
                 "sort",
@@ -234,6 +238,39 @@ class SearchClientAdapter:
                 body["from"] = body.pop("from_")
             return self._call(self.raw_client.search, body=body, **kwargs)
         return self._call(self.raw_client.search, **kwargs)
+
+    def open_point_in_time(self, **kwargs):
+        if self.backend == SearchBackend.ELASTICSEARCH:
+            return self._call(self.raw_client.open_point_in_time, **kwargs)
+
+        create_pit = getattr(self.raw_client, "create_pit", None)
+        if create_pit is None:
+            raise SearchBackendCompatibilityError(
+                "OpenSearch client does not expose create_pit; PIT requires opensearch-py with PIT API support"
+            )
+
+        params = {}
+        for key in ("keep_alive", "allow_partial_pit_creation", "expand_wildcards", "preference", "routing"):
+            if key in kwargs:
+                params[key] = kwargs.pop(key)
+
+        response = self._call(create_pit, params=params, **kwargs)
+        if isinstance(response, dict) and "id" not in response and "pit_id" in response:
+            return {"id": response["pit_id"]}
+        return response
+
+    def close_point_in_time(self, **kwargs):
+        if self.backend == SearchBackend.ELASTICSEARCH:
+            return self._call(self.raw_client.close_point_in_time, **kwargs)
+
+        delete_pit = getattr(self.raw_client, "delete_pit", None)
+        if delete_pit is None:
+            raise SearchBackendCompatibilityError(
+                "OpenSearch client does not expose delete_pit; PIT requires opensearch-py with PIT API support"
+            )
+
+        pit_id = kwargs.pop("id")
+        return self._call(delete_pit, body={"pit_id": [pit_id]}, **kwargs)
 
     def __getattr__(self, name):
         if self.backend == SearchBackend.ELASTICSEARCH:

--- a/assemblyline/datastore/compat.py
+++ b/assemblyline/datastore/compat.py
@@ -141,6 +141,38 @@ class _IndicesAdapter:
         raise UnsupportedSearchBackendOperation(f"indices.{name} is not supported by this adapter slice")
 
 
+class _TasksAdapter:
+    def __init__(self, adapter: "SearchClientAdapter"):
+        self._adapter = adapter
+
+    def get(self, **kwargs):
+        if self._adapter.backend == SearchBackend.ELASTICSEARCH:
+            return self._adapter._call(self._adapter.raw_client.tasks.get, **kwargs)
+
+        # opensearch-py 2.8 treats the tasks API timeout query parameter as a
+        # transport timeout, so Assemblyline enforces finite waits at ESStore.
+        kwargs.pop("timeout", None)
+        params = self._adapter._extract_opensearch_params(
+            kwargs,
+            {
+                "error_trace",
+                "filter_path",
+                "human",
+                "pretty",
+                "source",
+                "wait_for_completion",
+            },
+        )
+        params.pop("timeout", None)
+        self._adapter._reject_unsupported_kwargs("tasks.get", kwargs, {"task_id", "headers"})
+        return self._adapter._call(self._adapter.raw_client.tasks.get, params=params or None, **kwargs)
+
+    def __getattr__(self, name):
+        if self._adapter.backend == SearchBackend.ELASTICSEARCH:
+            return getattr(self._adapter.raw_client.tasks, name)
+        raise UnsupportedSearchBackendOperation(f"tasks.{name} is not supported by this adapter slice")
+
+
 class SearchClientAdapter:
     def __init__(self, raw_client: Any, backend: str = SearchBackend.ELASTICSEARCH):
         self.raw_client = raw_client
@@ -159,7 +191,7 @@ class SearchClientAdapter:
             self.ilm = _UnsupportedNamespace("ilm")
             self.nodes = _UnsupportedNamespace("nodes")
             self.security = _UnsupportedNamespace("security")
-            self.tasks = _UnsupportedNamespace("tasks")
+            self.tasks = _TasksAdapter(self)
 
     def _call(self, func: Callable, *args, **kwargs):
         try:
@@ -187,7 +219,10 @@ class SearchClientAdapter:
                 status = int(err.args[0])
             except (TypeError, ValueError):
                 pass
-        return int(status) if status is not None else None
+        try:
+            return int(status) if status is not None else None
+        except (TypeError, ValueError):
+            return None
 
     @classmethod
     def normalize_exception(cls, err: Exception) -> SearchBackendException:
@@ -196,6 +231,49 @@ class SearchClientAdapter:
 
         message = getattr(err, "message", None) or str(err)
         return SearchBackendException(message, status_code=cls.get_exception_status(err), original=err)
+
+    @staticmethod
+    def _opensearch_param_value(value):
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        return value
+
+    @classmethod
+    def _extract_opensearch_params(cls, kwargs: dict, supported_params: set[str]) -> dict:
+        params = {}
+        explicit_params = kwargs.pop("params", None)
+        if explicit_params:
+            params.update({
+                key: cls._opensearch_param_value(value)
+                for key, value in explicit_params.items()
+                if value is not None
+            })
+
+        for key in list(kwargs.keys()):
+            if key not in supported_params:
+                continue
+            value = kwargs.pop(key)
+            if value is not None:
+                params[key] = cls._opensearch_param_value(value)
+
+        return params
+
+    @staticmethod
+    def _extract_body_value(kwargs: dict, body: dict, key: str):
+        value = kwargs.pop(key, None)
+        if value is None:
+            return
+        if key in body:
+            raise SearchBackendCompatibilityError(f"{key} cannot be supplied both directly and in body")
+        body[key] = value
+
+    @staticmethod
+    def _reject_unsupported_kwargs(operation: str, kwargs: dict, allowed: set[str]):
+        unsupported = sorted(set(kwargs) - allowed)
+        if unsupported:
+            raise SearchBackendCompatibilityError(
+                f"{operation} does not support argument(s): {', '.join(unsupported)}"
+            )
 
     @staticmethod
     def opensearch_compatible_mappings(mappings: dict) -> dict:
@@ -296,6 +374,102 @@ class SearchClientAdapter:
                 body["sort"] = self.opensearch_compatible_sort(body["sort"])
             return self._call(self.raw_client.search, body=body, **kwargs)
         return self._call(self.raw_client.search, **kwargs)
+
+    def delete_by_query(self, **kwargs):
+        if self.backend == SearchBackend.ELASTICSEARCH:
+            return self._call(self.raw_client.delete_by_query, **kwargs)
+
+        body = kwargs.pop("body", {}) or {}
+        params = self._extract_opensearch_params(
+            kwargs,
+            {
+                "allow_no_indices",
+                "analyze_wildcard",
+                "analyzer",
+                "conflicts",
+                "default_operator",
+                "df",
+                "expand_wildcards",
+                "from_",
+                "ignore_unavailable",
+                "lenient",
+                "preference",
+                "q",
+                "refresh",
+                "request_cache",
+                "requests_per_second",
+                "routing",
+                "scroll",
+                "scroll_size",
+                "search_timeout",
+                "search_type",
+                "size",
+                "slices",
+                "sort",
+                "stats",
+                "terminate_after",
+                "timeout",
+                "version",
+                "wait_for_active_shards",
+                "wait_for_completion",
+            },
+        )
+        if "from_" in params:
+            params["from"] = params.pop("from_")
+        self._extract_body_value(kwargs, body, "query")
+        self._extract_body_value(kwargs, body, "max_docs")
+        self._extract_body_value(kwargs, body, "slice")
+        self._reject_unsupported_kwargs("delete_by_query", kwargs, {"index", "headers"})
+        return self._call(self.raw_client.delete_by_query, body=body, params=params or None, **kwargs)
+
+    def update_by_query(self, **kwargs):
+        if self.backend == SearchBackend.ELASTICSEARCH:
+            return self._call(self.raw_client.update_by_query, **kwargs)
+
+        body = kwargs.pop("body", {}) or {}
+        params = self._extract_opensearch_params(
+            kwargs,
+            {
+                "allow_no_indices",
+                "analyze_wildcard",
+                "analyzer",
+                "conflicts",
+                "default_operator",
+                "df",
+                "expand_wildcards",
+                "from_",
+                "ignore_unavailable",
+                "lenient",
+                "pipeline",
+                "preference",
+                "q",
+                "refresh",
+                "request_cache",
+                "requests_per_second",
+                "routing",
+                "scroll",
+                "scroll_size",
+                "search_timeout",
+                "search_type",
+                "size",
+                "slices",
+                "sort",
+                "stats",
+                "terminate_after",
+                "timeout",
+                "version",
+                "wait_for_active_shards",
+                "wait_for_completion",
+            },
+        )
+        if "from_" in params:
+            params["from"] = params.pop("from_")
+        self._extract_body_value(kwargs, body, "query")
+        self._extract_body_value(kwargs, body, "script")
+        self._extract_body_value(kwargs, body, "max_docs")
+        self._extract_body_value(kwargs, body, "slice")
+        self._reject_unsupported_kwargs("update_by_query", kwargs, {"index", "headers"})
+        return self._call(self.raw_client.update_by_query, body=body, params=params or None, **kwargs)
 
     def open_point_in_time(self, **kwargs):
         if self.backend == SearchBackend.ELASTICSEARCH:

--- a/assemblyline/datastore/compat.py
+++ b/assemblyline/datastore/compat.py
@@ -265,7 +265,13 @@ class SearchClientAdapter:
                 "_source",
                 "timeout",
             }
-            body = {key: kwargs.pop(key) for key in list(kwargs.keys()) if key in body_keys}
+            body = {}
+            for key in list(kwargs.keys()):
+                if key not in body_keys:
+                    continue
+                value = kwargs.pop(key)
+                if value is not None:
+                    body[key] = value
             if "from_" in body:
                 body["from"] = body.pop("from_")
             if "sort" in body:

--- a/assemblyline/datastore/compat.py
+++ b/assemblyline/datastore/compat.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from enum import Enum
 from typing import Any, Callable, Optional
 
@@ -92,7 +93,7 @@ class _IndicesAdapter:
         if self._adapter.backend == SearchBackend.OPENSEARCH:
             body = {}
             if mappings is not None:
-                body["mappings"] = mappings
+                body["mappings"] = self._adapter.opensearch_compatible_mappings(mappings)
             if settings is not None:
                 body["settings"] = settings
             return self._adapter._call(self._adapter.raw_client.indices.create, index=index, body=body, **kwargs)
@@ -112,6 +113,9 @@ class _IndicesAdapter:
 
     def refresh(self, **kwargs):
         return self._adapter._call(self._adapter.raw_client.indices.refresh, **kwargs)
+
+    def get(self, **kwargs):
+        return self._adapter._call(self._adapter.raw_client.indices.get, **kwargs)
 
     def __getattr__(self, name):
         if self._adapter.backend == SearchBackend.ELASTICSEARCH:
@@ -175,6 +179,32 @@ class SearchClientAdapter:
         message = getattr(err, "message", None) or str(err)
         return SearchBackendException(message, status_code=cls.get_exception_status(err), original=err)
 
+    @staticmethod
+    def opensearch_compatible_mappings(mappings: dict) -> dict:
+        compatible_mappings = deepcopy(mappings)
+
+        def replace_unsupported_types(value):
+            if isinstance(value, dict):
+                if value.get("type") == "wildcard":
+                    # OpenSearch 2.x has wildcard queries, but not Elasticsearch's wildcard field mapper.
+                    value["type"] = "keyword"
+                for child in value.values():
+                    replace_unsupported_types(child)
+            elif isinstance(value, list):
+                for child in value:
+                    replace_unsupported_types(child)
+
+        replace_unsupported_types(compatible_mappings)
+        return compatible_mappings
+
+    @staticmethod
+    def opensearch_compatible_sort(sort):
+        compatible_sort = deepcopy(sort)
+        for item in compatible_sort or []:
+            if isinstance(item, dict) and "_shard_doc" in item:
+                item["_doc"] = item.pop("_shard_doc")
+        return compatible_sort
+
     def info(self):
         return self._call(self.raw_client.info)
 
@@ -236,6 +266,8 @@ class SearchClientAdapter:
             body = {key: kwargs.pop(key) for key in list(kwargs.keys()) if key in body_keys}
             if "from_" in body:
                 body["from"] = body.pop("from_")
+            if "sort" in body:
+                body["sort"] = self.opensearch_compatible_sort(body["sort"])
             return self._call(self.raw_client.search, body=body, **kwargs)
         return self._call(self.raw_client.search, **kwargs)
 

--- a/assemblyline/datastore/compat.py
+++ b/assemblyline/datastore/compat.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Callable, Optional
+
+try:
+    import elasticsearch
+except ImportError:
+    elasticsearch = None
+
+
+class SearchBackend(str, Enum):
+    ELASTICSEARCH = "elasticsearch"
+    OPENSEARCH = "opensearch"
+
+
+class SearchBackendException(Exception):
+    def __init__(self, message: str, status_code: Optional[int] = None, original: Optional[Exception] = None):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.original = original
+
+
+class UnsupportedSearchBackendOperation(NotImplementedError):
+    pass
+
+
+def _load_opensearch_client():
+    try:
+        from opensearchpy import OpenSearch
+    except ImportError as err:
+        raise ImportError("OpenSearch backend requires the optional 'opensearch-py' package.") from err
+    return OpenSearch
+
+
+def create_search_client(
+    backend: str,
+    hosts,
+    *,
+    max_retries: int,
+    request_timeout: int,
+    ca_certs: Optional[str],
+    verify_certs: bool,
+) -> "SearchClientAdapter":
+    backend = SearchBackend(backend)
+    if backend == SearchBackend.ELASTICSEARCH:
+        if elasticsearch is None:
+            raise ImportError("Elasticsearch backend requires the 'elasticsearch' package.")
+        raw_client = elasticsearch.Elasticsearch(
+            hosts=hosts,
+            max_retries=max_retries,
+            request_timeout=request_timeout,
+            ca_certs=ca_certs,
+            verify_certs=verify_certs,
+        )
+    elif backend == SearchBackend.OPENSEARCH:
+        opensearch_client = _load_opensearch_client()
+        raw_client = opensearch_client(
+            hosts=hosts,
+            max_retries=max_retries,
+            timeout=request_timeout,
+            ca_certs=ca_certs,
+            verify_certs=verify_certs,
+        )
+    else:
+        raise ValueError(f"Unsupported search backend: {backend}")
+
+    return SearchClientAdapter(raw_client, backend)
+
+
+class _UnsupportedNamespace:
+    def __init__(self, namespace: str):
+        self.namespace = namespace
+
+    def __getattr__(self, name):
+        raise UnsupportedSearchBackendOperation(f"{self.namespace}.{name} is not supported by this adapter slice")
+
+
+class _IndicesAdapter:
+    def __init__(self, adapter: "SearchClientAdapter"):
+        self._adapter = adapter
+
+    def exists(self, **kwargs):
+        return self._adapter._call(self._adapter.raw_client.indices.exists, **kwargs)
+
+    def create(self, *, index, mappings=None, settings=None, **kwargs):
+        if self._adapter.backend == SearchBackend.OPENSEARCH:
+            body = {}
+            if mappings is not None:
+                body["mappings"] = mappings
+            if settings is not None:
+                body["settings"] = settings
+            return self._adapter._call(self._adapter.raw_client.indices.create, index=index, body=body, **kwargs)
+        return self._adapter._call(
+            self._adapter.raw_client.indices.create,
+            index=index,
+            mappings=mappings,
+            settings=settings,
+            **kwargs,
+        )
+
+    def put_alias(self, **kwargs):
+        return self._adapter._call(self._adapter.raw_client.indices.put_alias, **kwargs)
+
+    def exists_alias(self, **kwargs):
+        return self._adapter._call(self._adapter.raw_client.indices.exists_alias, **kwargs)
+
+    def refresh(self, **kwargs):
+        return self._adapter._call(self._adapter.raw_client.indices.refresh, **kwargs)
+
+    def __getattr__(self, name):
+        if self._adapter.backend == SearchBackend.ELASTICSEARCH:
+            return getattr(self._adapter.raw_client.indices, name)
+        raise UnsupportedSearchBackendOperation(f"indices.{name} is not supported by this adapter slice")
+
+
+class SearchClientAdapter:
+    def __init__(self, raw_client: Any, backend: str = SearchBackend.ELASTICSEARCH):
+        self.raw_client = raw_client
+        self.backend = SearchBackend(backend)
+        self.indices = _IndicesAdapter(self)
+        if self.backend == SearchBackend.ELASTICSEARCH:
+            self.cat = raw_client.cat
+            self.cluster = raw_client.cluster
+            self.ilm = raw_client.ilm
+            self.nodes = raw_client.nodes
+            self.security = raw_client.security
+            self.tasks = raw_client.tasks
+        else:
+            self.cat = _UnsupportedNamespace("cat")
+            self.cluster = _UnsupportedNamespace("cluster")
+            self.ilm = _UnsupportedNamespace("ilm")
+            self.nodes = _UnsupportedNamespace("nodes")
+            self.security = _UnsupportedNamespace("security")
+            self.tasks = _UnsupportedNamespace("tasks")
+
+    def _call(self, func: Callable, *args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as err:
+            if self.backend == SearchBackend.ELASTICSEARCH:
+                raise
+            raise self.normalize_exception(err) from err
+
+    @staticmethod
+    def get_exception_status(err: Exception) -> Optional[int]:
+        if isinstance(err, SearchBackendException):
+            return err.status_code
+
+        status = getattr(err, "status_code", None)
+        if status is None:
+            meta = getattr(err, "meta", None)
+            status = getattr(meta, "status", None)
+        if status is None:
+            info = getattr(err, "info", None)
+            if isinstance(info, dict):
+                status = info.get("status")
+        if status is None and getattr(err, "args", None):
+            try:
+                status = int(err.args[0])
+            except (TypeError, ValueError):
+                pass
+        return int(status) if status is not None else None
+
+    @classmethod
+    def normalize_exception(cls, err: Exception) -> SearchBackendException:
+        if isinstance(err, SearchBackendException):
+            return err
+
+        message = getattr(err, "message", None) or str(err)
+        return SearchBackendException(message, status_code=cls.get_exception_status(err), original=err)
+
+    def info(self):
+        return self._call(self.raw_client.info)
+
+    def ping(self):
+        return self._call(self.raw_client.ping)
+
+    def close(self):
+        return self.raw_client.close()
+
+    def exists(self, **kwargs):
+        return self._call(self.raw_client.exists, **kwargs)
+
+    def get(self, **kwargs):
+        return self._call(self.raw_client.get, **kwargs)
+
+    def index(self, *, document=None, **kwargs):
+        if self.backend == SearchBackend.OPENSEARCH:
+            return self._call(self.raw_client.index, body=document, **kwargs)
+        return self._call(self.raw_client.index, document=document, **kwargs)
+
+    def delete(self, **kwargs):
+        return self._call(self.raw_client.delete, **kwargs)
+
+    def update(self, **kwargs):
+        if self.backend == SearchBackend.OPENSEARCH:
+            script = kwargs.pop("script", None)
+            body = kwargs.pop("body", {})
+            if script is not None:
+                body = {**body, "script": script}
+            return self._call(self.raw_client.update, body=body, **kwargs)
+        return self._call(self.raw_client.update, **kwargs)
+
+    def mget(self, *, ids=None, **kwargs):
+        if self.backend == SearchBackend.OPENSEARCH:
+            return self._call(self.raw_client.mget, body={"ids": ids}, **kwargs)
+        return self._call(self.raw_client.mget, ids=ids, **kwargs)
+
+    def bulk(self, *, operations=None, **kwargs):
+        if self.backend == SearchBackend.OPENSEARCH:
+            return self._call(self.raw_client.bulk, body=operations, **kwargs)
+        return self._call(self.raw_client.bulk, operations=operations, **kwargs)
+
+    def search(self, **kwargs):
+        if self.backend == SearchBackend.OPENSEARCH:
+            if "pit" in kwargs or "search_after" in kwargs:
+                raise UnsupportedSearchBackendOperation("OpenSearch PIT search is not supported by this adapter slice")
+            body_keys = {
+                "aggregations",
+                "collapse",
+                "from_",
+                "query",
+                "script_fields",
+                "seq_no_primary_term",
+                "size",
+                "sort",
+                "_source",
+                "timeout",
+            }
+            body = {key: kwargs.pop(key) for key in list(kwargs.keys()) if key in body_keys}
+            if "from_" in body:
+                body["from"] = body.pop("from_")
+            return self._call(self.raw_client.search, body=body, **kwargs)
+        return self._call(self.raw_client.search, **kwargs)
+
+    def __getattr__(self, name):
+        if self.backend == SearchBackend.ELASTICSEARCH:
+            return getattr(self.raw_client, name)
+        raise UnsupportedSearchBackendOperation(f"{name} is not supported by this adapter slice")

--- a/assemblyline/datastore/compat.py
+++ b/assemblyline/datastore/compat.py
@@ -187,6 +187,8 @@ class SearchClientAdapter:
             if isinstance(value, dict):
                 if value.get("type") == "wildcard":
                     # OpenSearch 2.x has wildcard queries, but not Elasticsearch's wildcard field mapper.
+                    # Keyword preserves Assemblyline metadata's exact/wildcard/regexp query behavior for
+                    # term-sized values; over-limit values reject instead of being silently ignored.
                     value["type"] = "keyword"
                 for child in value.values():
                     replace_unsupported_types(child)

--- a/assemblyline/datastore/compat.py
+++ b/assemblyline/datastore/compat.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from copy import deepcopy
 from enum import Enum
+import base64
+import json
+import ssl
 from typing import Any, Callable, Optional
+from urllib.error import HTTPError, URLError
+from urllib.parse import unquote, urlsplit, urlunsplit
+from urllib.request import Request, urlopen
 
 try:
     import elasticsearch
@@ -29,6 +35,93 @@ class UnsupportedSearchBackendOperation(NotImplementedError):
 
 class SearchBackendCompatibilityError(UnsupportedSearchBackendOperation):
     pass
+
+
+class SearchBackendDetectionError(Exception):
+    pass
+
+
+class SearchBackendAuthenticationError(SearchBackendDetectionError):
+    pass
+
+
+class SearchBackendConnectionError(SearchBackendDetectionError):
+    pass
+
+
+class SearchBackendMalformedResponseError(SearchBackendDetectionError):
+    pass
+
+
+class SearchBackendAmbiguousResponseError(SearchBackendDetectionError):
+    pass
+
+
+class UnsupportedSearchBackendError(SearchBackendDetectionError):
+    pass
+
+
+def detect_search_backend(hosts, *, request_timeout: int, ca_certs: Optional[str],
+                          verify_certs: bool) -> SearchBackend:
+    """Identify the configured search product with one authenticated root request."""
+    if not hosts:
+        raise SearchBackendConnectionError("Search backend detection requires at least one configured host.")
+
+    parsed = urlsplit(hosts[0])
+    if not parsed.scheme or not parsed.hostname:
+        raise SearchBackendConnectionError("Search backend detection could not use the configured host.")
+
+    hostname = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+    netloc = f"{hostname}:{parsed.port}" if parsed.port is not None else hostname
+    endpoint = urlunsplit((parsed.scheme, netloc, "/", "", ""))
+    headers = {"Accept": "application/json"}
+    if parsed.username is not None:
+        credentials = f"{unquote(parsed.username)}:{unquote(parsed.password or '')}".encode()
+        headers["Authorization"] = f"Basic {base64.b64encode(credentials).decode('ascii')}"
+
+    try:
+        context = None
+        if parsed.scheme == "https":
+            if verify_certs:
+                context = ssl.create_default_context(cafile=ca_certs)
+            else:
+                context = ssl._create_unverified_context()
+        response = urlopen(Request(endpoint, headers=headers), timeout=request_timeout, context=context)
+        with response:
+            product_header = response.headers.get("X-Elastic-Product")
+            payload = json.loads(response.read())
+    except HTTPError as err:
+        if err.code in (401, 403):
+            raise SearchBackendAuthenticationError(
+                f"Search backend detection authentication failed with HTTP status {err.code}.") from None
+        raise SearchBackendConnectionError(
+            f"Search backend detection request failed with HTTP status {err.code}.") from None
+    except (URLError, TimeoutError, OSError):
+        raise SearchBackendConnectionError("Search backend detection could not connect to the configured server.") from None
+    except (json.JSONDecodeError, UnicodeDecodeError, TypeError, ValueError):
+        raise SearchBackendMalformedResponseError(
+            "Search backend detection received malformed JSON from the configured server.") from None
+
+    if not isinstance(payload, dict):
+        raise SearchBackendMalformedResponseError(
+            "Search backend detection expected a JSON object from the configured server.")
+
+    is_elasticsearch = product_header == "Elasticsearch"
+    version_info = payload.get("version")
+    if version_info is not None and not isinstance(version_info, dict):
+        raise SearchBackendMalformedResponseError(
+            "Search backend detection received malformed version metadata.")
+    is_opensearch = isinstance(version_info, dict) and version_info.get("distribution") == "opensearch"
+
+    if is_elasticsearch and is_opensearch:
+        raise SearchBackendAmbiguousResponseError(
+            "Search backend detection received conflicting Elasticsearch and OpenSearch product indicators.")
+    if is_elasticsearch:
+        return SearchBackend.ELASTICSEARCH
+    if is_opensearch:
+        return SearchBackend.OPENSEARCH
+    raise UnsupportedSearchBackendError(
+        "Search backend detection found no supported Elasticsearch or OpenSearch product indicator.")
 
 
 def _load_opensearch_client():

--- a/assemblyline/datastore/compat.py
+++ b/assemblyline/datastore/compat.py
@@ -114,6 +114,24 @@ class _IndicesAdapter:
     def refresh(self, **kwargs):
         return self._adapter._call(self._adapter.raw_client.indices.refresh, **kwargs)
 
+    def clear_cache(self, **kwargs):
+        if self._adapter.backend == SearchBackend.OPENSEARCH:
+            params = {}
+            for key in (
+                "allow_no_indices",
+                "expand_wildcards",
+                "fielddata",
+                "fields",
+                "ignore_unavailable",
+                "query",
+                "request",
+            ):
+                if key in kwargs:
+                    params[key] = kwargs.pop(key)
+            if params:
+                kwargs["params"] = params
+        return self._adapter._call(self._adapter.raw_client.indices.clear_cache, **kwargs)
+
     def get(self, **kwargs):
         return self._adapter._call(self._adapter.raw_client.indices.get, **kwargs)
 

--- a/assemblyline/datastore/store.py
+++ b/assemblyline/datastore/store.py
@@ -5,6 +5,7 @@ import re
 import time
 import typing
 import warnings
+
 from os import environ, path
 from random import random
 from urllib.parse import urlparse
@@ -294,7 +295,12 @@ class ESStore(object):
                                      max_docs=max_tasks)
 
         # Wait until the tasks deletion task is over
-        res = self._get_task_results(task)
+        try:
+            res = self._get_task_results(task)
+        except DataStoreException as err:
+            if "restricted indices [.tasks]" in str(err):
+                return 0
+            raise
 
         # return the number of deleted items
         return res['deleted']
@@ -308,8 +314,15 @@ class ESStore(object):
         if retry_function is None:
             retry_function = self.with_retries
 
+        deadline = None
+        task_wait_timeout = self.__dict__.get("task_wait_timeout")
+        if task_wait_timeout is not None:
+            deadline = time.monotonic() + task_wait_timeout
+
         res = None
         while res is None:
+            if deadline is not None and time.monotonic() > deadline:
+                raise DataStoreException(f"Timed out waiting for datastore task {task['task']}")
             try:
                 res = retry_function(self.client.tasks.get, task_id=task['task'],
                                      wait_for_completion=True, timeout='5s')
@@ -327,6 +340,14 @@ class ESStore(object):
                     pass
                 else:
                     raise
+
+        if 'error' in res:
+            error = res['error']
+            if isinstance(error, dict):
+                reason = error.get('reason') or error.get('type') or str(error)
+            else:
+                reason = str(error)
+            raise DataStoreException(f"Datastore task {task['task']} failed: {reason}")
 
         try:
             return res['response']

--- a/assemblyline/datastore/store.py
+++ b/assemblyline/datastore/store.py
@@ -72,9 +72,11 @@ class ESStore(object):
     }
     ID = 'id'
     MIN_ELASTIC_VERSION = '7.10'
+    MIN_OPENSEARCH_VERSION = '2.12.0'
 
-    def __init__(self, hosts, archive_access=True, archive_alernate_dtl=0):
+    def __init__(self, hosts, backend=SearchBackend.ELASTICSEARCH, archive_access=True, archive_alernate_dtl=0):
         config = forge.get_config()
+        self.backend = SearchBackend(backend)
         self._hosts = hosts
         self._closed = False
         self._collections = {}
@@ -89,17 +91,13 @@ class ESStore(object):
         self.ca_certs = None if not path.exists(DATASTORE_ROOT_CA_PATH) else DATASTORE_ROOT_CA_PATH
 
         self.client = create_search_client(
-            SearchBackend.ELASTICSEARCH,
-            hosts,
-            max_retries=0,
-            request_timeout=TRANSPORT_TIMEOUT,
-            ca_certs=self.ca_certs,
-            verify_certs=DATASTORE_VERIFY_CERTS,
-        )
-        self.es_version = version.parse(self.with_retries(self.client.info)['version']['number'])
+            self.backend, hosts, max_retries=0, request_timeout=TRANSPORT_TIMEOUT,
+            ca_certs=self.ca_certs, verify_certs=DATASTORE_VERIFY_CERTS)
+        self.version_info = self.with_retries(self.client.info).get('version', {})
+        self.es_version = version.parse(self.version_info['number'])
         self.archive_access = archive_access
         self.url_path = 'elastic'
-        self._test_elastic_minimum_version()
+        self._test_minimum_version()
 
     def __enter__(self):
         return self
@@ -171,10 +169,21 @@ class ESStore(object):
     def date_separator(self):
         return self.DATE_FORMAT['SEPARATOR']
 
-    def _test_elastic_minimum_version(self):
-        if not self.is_supported_version(self.MIN_ELASTIC_VERSION):
-            raise UnsupportedElasticVersion(f"Elastic version {self.es_version} is not supported by Assemblyline. "
-                                            f"Upgrade to Elastic {self.MIN_ELASTIC_VERSION} at minimum.")
+    def _test_minimum_version(self):
+        if self.backend == SearchBackend.ELASTICSEARCH:
+            if not self.is_supported_version(self.MIN_ELASTIC_VERSION):
+                raise UnsupportedElasticVersion(f"Elastic version {self.es_version} is not supported by Assemblyline. "
+                                                f"Upgrade to Elastic {self.MIN_ELASTIC_VERSION} at minimum.")
+            return
+
+        if self.version_info.get("distribution") != "opensearch":
+            raise UnsupportedElasticVersion(
+                f"OpenSearch backend selected but datastore identified as "
+                f"{self.version_info.get('distribution', 'unknown')} {self.es_version}.")
+
+        if not self.is_supported_version(self.MIN_OPENSEARCH_VERSION):
+            raise UnsupportedElasticVersion(f"OpenSearch version {self.es_version} is not supported by Assemblyline. "
+                                            f"Upgrade to OpenSearch {self.MIN_OPENSEARCH_VERSION} at minimum.")
 
     def is_supported_version(self, min):
         return self.es_version >= version.parse(min)
@@ -208,17 +217,18 @@ class ESStore(object):
 
     def connection_reset(self):
         self.client = create_search_client(
-            SearchBackend.ELASTICSEARCH,
+            self.backend,
             self._hosts,
             max_retries=0,
             request_timeout=TRANSPORT_TIMEOUT,
             ca_certs=self.ca_certs,
-            verify_certs=DATASTORE_VERIFY_CERTS,
-        )
-        log.info("Reconnected to Elasticsearch")
+            verify_certs=DATASTORE_VERIFY_CERTS)
+        log.info("Reconnected to %s", self.backend.value)
 
     def close(self):
         self._closed = True
+        if self.client is not None:
+            self.client.close()
         # Flatten the client object so that attempts to access without reconnecting errors hard
         # But 'cast' it so that mypy and other linters don't think that its normal for client to be None
         self.client = typing.cast(object, None)

--- a/assemblyline/datastore/store.py
+++ b/assemblyline/datastore/store.py
@@ -194,6 +194,13 @@ class ESStore(object):
             log.warning(f"Unknown alternative user '{username}' to switch to for Elasticsearch")
             return
 
+        if self.backend == SearchBackend.OPENSEARCH:
+            # OpenSearch deployments use the configured service identity here. The Elasticsearch
+            # plumber switch relies on Elasticsearch-only security client APIs and restricted-index
+            # behavior, neither of which applies to the current OpenSearch test deployment.
+            log.info("Skipping alternative datastore user '%s' for OpenSearch", username)
+            return
+
         if username == "plumber":
             # Ensure roles for "plumber" user are created
             self.with_retries(

--- a/assemblyline/datastore/store.py
+++ b/assemblyline/datastore/store.py
@@ -11,12 +11,22 @@ from urllib.parse import urlparse
 
 import elasticsearch
 import elasticsearch.helpers
+from packaging import version
+
 from assemblyline.common import forge
 from assemblyline.common.isotime import now
 from assemblyline.common.security import generate_random_secret
 from assemblyline.datastore.collection import ESCollection
-from assemblyline.datastore.exceptions import DataStoreException, UnsupportedElasticVersion, VersionConflictException
-from packaging import version
+from assemblyline.datastore.compat import (
+    SearchBackend,
+    SearchBackendException,
+    create_search_client,
+)
+from assemblyline.datastore.exceptions import (
+    DataStoreException,
+    UnsupportedElasticVersion,
+    VersionConflictException,
+)
 
 TRANSPORT_TIMEOUT = int(environ.get('AL_DATASTORE_TRANSPORT_TIMEOUT', '90'))
 DATASTORE_ROOT_CA_PATH = environ.get('DATASTORE_ROOT_CA_PATH', '/etc/assemblyline/ssl/al_root-ca.crt')
@@ -78,8 +88,14 @@ class ESStore(object):
 
         self.ca_certs = None if not path.exists(DATASTORE_ROOT_CA_PATH) else DATASTORE_ROOT_CA_PATH
 
-        self.client = elasticsearch.Elasticsearch(hosts=hosts, max_retries=0, request_timeout=TRANSPORT_TIMEOUT,
-                                                  ca_certs=self.ca_certs, verify_certs=DATASTORE_VERIFY_CERTS)
+        self.client = create_search_client(
+            SearchBackend.ELASTICSEARCH,
+            hosts,
+            max_retries=0,
+            request_timeout=TRANSPORT_TIMEOUT,
+            ca_certs=self.ca_certs,
+            verify_certs=DATASTORE_VERIFY_CERTS,
+        )
         self.es_version = version.parse(self.with_retries(self.client.info)['version']['number'])
         self.archive_access = archive_access
         self.url_path = 'elastic'
@@ -191,18 +207,21 @@ class ESStore(object):
         self.connection_reset()
 
     def connection_reset(self):
-        self.client = elasticsearch.Elasticsearch(hosts=self._hosts,
-                                                  max_retries=0,
-                                                  request_timeout=TRANSPORT_TIMEOUT,
-                                                  ca_certs=self.ca_certs,
-                                                  verify_certs=DATASTORE_VERIFY_CERTS)
+        self.client = create_search_client(
+            SearchBackend.ELASTICSEARCH,
+            self._hosts,
+            max_retries=0,
+            request_timeout=TRANSPORT_TIMEOUT,
+            ca_certs=self.ca_certs,
+            verify_certs=DATASTORE_VERIFY_CERTS,
+        )
         log.info("Reconnected to Elasticsearch")
 
     def close(self):
         self._closed = True
         # Flatten the client object so that attempts to access without reconnecting errors hard
         # But 'cast' it so that mypy and other linters don't think that its normal for client to be None
-        self.client = typing.cast(elasticsearch.Elasticsearch, None)
+        self.client = typing.cast(object, None)
 
     def get_hosts(self, safe=False):
         if not safe:
@@ -427,5 +446,38 @@ class ESStore(object):
                     raise
 
                 # Loop and retry
+                time.sleep(min(retries, self.MAX_RETRY_BACKOFF))
+                retries += 1
+
+            except SearchBackendException as err:
+                index_name = kwargs.get('index', '').upper()
+                err_code = err.status_code
+
+                if err_code == 409:
+                    if raise_conflicts:
+                        time.sleep(random() * 0.1)
+                        raise VersionConflictException(str(err))
+
+                    original_info = getattr(err.original, "info", {})
+                    if isinstance(original_info, dict):
+                        updated += original_info.get('updated', 0)
+                        deleted += original_info.get('deleted', 0)
+                elif err_code == 404 and index_name and "No search context found" in err.message:
+                    log.warning(f"Index {index_name} was removed while a query was running, retrying...")
+                elif err_code == 429:
+                    if index_name:
+                        log.warning("Elasticsearch is too busy to perform the requested "
+                                    f"task on index {index_name}, retrying...")
+                    else:
+                        log.warning("Elasticsearch is too busy to perform the requested "
+                                    f"task ({str(err)}), retrying...")
+                elif err_code == 503 and index_name:
+                    log.warning(f"Looks like index {index_name} is not ready yet, retrying...")
+                elif err_code == 403 and index_name:
+                    log.warning("Elasticsearch cluster is preventing writing operations "
+                                f"on index {index_name}, retrying...")
+                else:
+                    raise
+
                 time.sleep(min(retries, self.MAX_RETRY_BACKOFF))
                 retries += 1

--- a/assemblyline/datastore/store.py
+++ b/assemblyline/datastore/store.py
@@ -22,6 +22,7 @@ from assemblyline.datastore.compat import (
     SearchBackend,
     SearchBackendException,
     create_search_client,
+    detect_search_backend,
 )
 from assemblyline.datastore.exceptions import (
     DataStoreException,
@@ -77,7 +78,6 @@ class ESStore(object):
 
     def __init__(self, hosts, backend=SearchBackend.ELASTICSEARCH, archive_access=True, archive_alernate_dtl=0):
         config = forge.get_config()
-        self.backend = SearchBackend(backend)
         self._hosts = hosts
         self._closed = False
         self._collections = {}
@@ -90,6 +90,12 @@ class ESStore(object):
         tracer.setLevel(logging.CRITICAL)
 
         self.ca_certs = None if not path.exists(DATASTORE_ROOT_CA_PATH) else DATASTORE_ROOT_CA_PATH
+        self.backend = (
+            detect_search_backend(
+                hosts, request_timeout=TRANSPORT_TIMEOUT, ca_certs=self.ca_certs,
+                verify_certs=DATASTORE_VERIFY_CERTS)
+            if backend == "auto" else SearchBackend(backend)
+        )
 
         self.client = create_search_client(
             self.backend, hosts, max_retries=0, request_timeout=TRANSPORT_TIMEOUT,

--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -1091,7 +1091,8 @@ class Datastore(odm.Model):
     cache_dtl = odm.Integer(
         min=0,
         default=5, description="Default cache lenght for computed indices (submission_tree, submission_summary...")
-    type = odm.Enum({"elasticsearch"}, description="Type of application used for the datastore")
+    type = odm.Enum({"elasticsearch", "opensearch"}, default="elasticsearch",
+                    description="Type of application used for the datastore")
 
 
 DEFAULT_DATASTORE = {

--- a/assemblyline/odm/models/config.py
+++ b/assemblyline/odm/models/config.py
@@ -1091,7 +1091,7 @@ class Datastore(odm.Model):
     cache_dtl = odm.Integer(
         min=0,
         default=5, description="Default cache lenght for computed indices (submission_tree, submission_summary...")
-    type = odm.Enum({"elasticsearch", "opensearch"}, default="elasticsearch",
+    type = odm.Enum({"auto", "elasticsearch", "opensearch"}, default="elasticsearch",
                     description="Type of application used for the datastore")
 
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'redis',
         'requests[socks]',
         'elasticsearch>=8.0.0,<9.0.0',
+        'opensearch-py>=2.8.0,<3.0.0',
         'python-datemath!=3.0.2',
         'packaging',
         'PyYAML',
@@ -77,7 +78,6 @@ setup(
             'pytest-mock',
             'pyftpdlib',
             'pyopenssl==23.3.0',
-            'opensearch-py>=2.8.0,<3.0.0',
         ]
     },
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
             'pytest-mock',
             'pyftpdlib',
             'pyopenssl==23.3.0',
+            'opensearch-py>=2.8.0,<3.0.0',
         ]
     },
     package_data={

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,8 +2,11 @@
 Pytest configuration file, setup global pytest fixtures and functions here.
 """
 import os
+import time
+import uuid
 
 from assemblyline.common import forge
+from assemblyline.datastore.compat import SearchBackend, create_search_client
 from assemblyline.datastore.helper import AssemblylineDatastore
 from assemblyline.datastore.store import ESStore, ESCollection
 from redis.exceptions import ConnectionError
@@ -64,3 +67,46 @@ def redis_connection():
         pass
 
     return pytest.skip("Connection to the Redis server failed. This test cannot be performed...")
+
+
+@pytest.fixture
+def opensearch_client(request):
+    host = os.environ.get('AL_TEST_OPENSEARCH_HOST', 'http://127.0.0.1:9201')
+    timeout = int(os.environ.get('AL_TEST_OPENSEARCH_TIMEOUT', '60'))
+    deadline = time.monotonic() + timeout
+    last_error = None
+
+    while time.monotonic() < deadline:
+        try:
+            client = create_search_client(
+                SearchBackend.OPENSEARCH,
+                [host],
+                max_retries=0,
+                request_timeout=10,
+                ca_certs=None,
+                verify_certs=False,
+            )
+            if client.ping():
+                break
+            last_error = "ping returned false"
+        except Exception as err:
+            last_error = err
+        time.sleep(1)
+    else:
+        pytest.fail(f"OpenSearch test service at {host} is not healthy after {timeout}s: {last_error}")
+
+    index_prefix = f"al_os_test_{uuid.uuid4().hex}_"
+
+    def make_index_name(name):
+        return f"{index_prefix}{name}"
+
+    client.make_index_name = make_index_name
+
+    def cleanup():
+        try:
+            client.raw_client.indices.delete(index=f"{index_prefix}*", ignore_unavailable=True)
+        finally:
+            client.close()
+
+    request.addfinalizer(cleanup)
+    return client

--- a/test/docker-compose-opensearch.yml
+++ b/test/docker-compose-opensearch.yml
@@ -1,0 +1,18 @@
+services:
+  opensearch:
+    # OpenSearch 2.12.x supports the PIT API exercised by the adapter tests
+    # and is compatible with the opensearch-py 2.x client line.
+    image: opensearchproject/opensearch:2.12.0
+    environment:
+      - discovery.type=single-node
+      - DISABLE_INSTALL_DEMO_CONFIG=true
+      - plugins.security.disabled=true
+      - logger.level=WARN
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+    ports:
+      - "9201:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl --silent --fail http://localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 12

--- a/test/test_datastore_compat.py
+++ b/test/test_datastore_compat.py
@@ -728,6 +728,23 @@ def test_store_opensearch_rejects_unsupported_version(monkeypatch):
         ESStore(["http://opensearch:9200"], backend=SearchBackend.OPENSEARCH)
 
 
+def test_store_opensearch_switch_user_keeps_service_identity(monkeypatch):
+    client = make_store_client("2.12.0", distribution="opensearch")
+    factory = Mock(return_value=client)
+    monkeypatch.setattr("assemblyline.datastore.store.create_search_client", factory)
+
+    store = ESStore(["http://service:secret@opensearch:9200"], backend=SearchBackend.OPENSEARCH)
+
+    store.switch_user("plumber")
+
+    assert store.client is client
+    assert store.get_hosts() == ["http://service:secret@opensearch:9200"]
+    client.raw_client.security.put_role.assert_not_called()
+    client.raw_client.security.put_user.assert_not_called()
+    client.raw_client.close.assert_not_called()
+    assert factory.call_count == 1
+
+
 def test_forge_get_datastore_defaults_to_elasticsearch(monkeypatch):
     created = []
 

--- a/test/test_datastore_compat.py
+++ b/test/test_datastore_compat.py
@@ -8,6 +8,7 @@ from elastic_transport import ApiResponseMeta, NodeConfig
 from assemblyline.datastore.collection import ESCollection
 from assemblyline.datastore.compat import (
     SearchBackend,
+    SearchBackendCompatibilityError,
     SearchBackendException,
     SearchClientAdapter,
     UnsupportedSearchBackendOperation,
@@ -30,9 +31,13 @@ def make_raw_client():
         index=Mock(return_value={"result": "created"}),
         info=Mock(return_value={"version": {"number": "8.10.2"}}),
         mget=Mock(return_value={"docs": []}),
+        open_point_in_time=Mock(return_value={"id": "es-pit"}),
         ping=Mock(return_value=True),
         search=Mock(return_value={"hits": {"hits": []}}),
         update=Mock(return_value={"result": "updated"}),
+        close_point_in_time=Mock(return_value={"succeeded": True, "num_freed": 1}),
+        create_pit=Mock(return_value={"pit_id": "os-pit"}),
+        delete_pit=Mock(return_value={"pits": [{"pit_id": "os-pit", "successful": True}]}),
         cat=SimpleNamespace(nodes=Mock()),
         cluster=SimpleNamespace(health=Mock()),
         ilm=SimpleNamespace(get_lifecycle=Mock()),
@@ -73,6 +78,26 @@ def test_elasticsearch_adapter_preserves_es8_keywords():
 
     adapter.search(index="alert", query={"match_all": {}}, from_=1, size=10)
     raw.search.assert_called_once_with(index="alert", query={"match_all": {}}, from_=1, size=10)
+
+
+def test_elasticsearch_pit_open_call_is_forwarded_unchanged():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.ELASTICSEARCH)
+
+    response = adapter.open_point_in_time(index="alert", keep_alive="1m", preference="_local")
+
+    assert response == {"id": "es-pit"}
+    raw.open_point_in_time.assert_called_once_with(index="alert", keep_alive="1m", preference="_local")
+
+
+def test_elasticsearch_pit_close_call_is_forwarded_unchanged():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.ELASTICSEARCH)
+
+    response = adapter.close_point_in_time(id="es-pit")
+
+    assert response == {"succeeded": True, "num_freed": 1}
+    raw.close_point_in_time.assert_called_once_with(id="es-pit")
 
 
 def test_opensearch_index_document_translates_to_body():
@@ -141,6 +166,86 @@ def test_opensearch_search_translates_query_structure_to_body():
     )
 
 
+def test_opensearch_pit_search_translates_paging_fields_to_body():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    adapter.search(
+        pit={"id": "os-pit", "keep_alive": "1m"},
+        query={"match_all": {}},
+        search_after=[10, "doc"],
+        size=100,
+        sort=[{"_shard_doc": "desc"}],
+        _source=["id", "event"],
+    )
+
+    raw.search.assert_called_once_with(
+        body={
+            "pit": {"id": "os-pit", "keep_alive": "1m"},
+            "query": {"match_all": {}},
+            "search_after": [10, "doc"],
+            "size": 100,
+            "sort": [{"_shard_doc": "desc"}],
+            "_source": ["id", "event"],
+        },
+    )
+
+
+def test_opensearch_pit_open_call_translates_to_create_pit_api():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    adapter.open_point_in_time(index="alert", keep_alive="1m", preference="_local")
+
+    raw.create_pit.assert_called_once_with(index="alert", params={"keep_alive": "1m", "preference": "_local"})
+
+
+def test_opensearch_pit_open_response_normalizes_pit_id_to_id():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    response = adapter.open_point_in_time(index="alert", keep_alive="1m")
+
+    assert response == {"id": "os-pit"}
+
+
+def test_opensearch_pit_close_call_translates_to_delete_pit_body():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    response = adapter.close_point_in_time(id="os-pit")
+
+    assert response == {"pits": [{"pit_id": "os-pit", "successful": True}]}
+    raw.delete_pit.assert_called_once_with(body={"pit_id": ["os-pit"]})
+
+
+def test_opensearch_pit_exceptions_are_wrapped():
+    raw = make_raw_client()
+    original = Exception("pit failed")
+    original.status_code = 503
+    raw.create_pit.side_effect = original
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    with pytest.raises(SearchBackendException) as exc:
+        adapter.open_point_in_time(index="alert", keep_alive="1m")
+
+    assert exc.value.status_code == 503
+    assert exc.value.original is original
+
+
+def test_missing_opensearch_pit_support_fails_clearly():
+    raw = make_raw_client()
+    delattr(raw, "create_pit")
+    delattr(raw, "delete_pit")
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    with pytest.raises(SearchBackendCompatibilityError, match="create_pit"):
+        adapter.open_point_in_time(index="alert", keep_alive="1m")
+
+    with pytest.raises(SearchBackendCompatibilityError, match="delete_pit"):
+        adapter.close_point_in_time(id="os-pit")
+
+
 def test_opensearch_update_translates_script_to_body():
     raw = make_raw_client()
     adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
@@ -189,9 +294,6 @@ def test_unsupported_opensearch_operations_fail_clearly():
 
     with pytest.raises(UnsupportedSearchBackendOperation):
         adapter.cluster.health()
-
-    with pytest.raises(UnsupportedSearchBackendOperation):
-        adapter.search(index="alert", pit={"id": "pit"}, search_after=[1])
 
 
 def test_elasticsearch_delegates_existing_unsupported_operation_to_raw_client():

--- a/test/test_datastore_compat.py
+++ b/test/test_datastore_compat.py
@@ -46,6 +46,7 @@ def make_raw_client():
             create=Mock(return_value={"acknowledged": True}),
             exists=Mock(return_value=True),
             exists_alias=Mock(return_value=False),
+            get=Mock(return_value={"alert": {"mappings": {"properties": {}}}}),
             put_alias=Mock(return_value={"acknowledged": True}),
             refresh=Mock(return_value={"_shards": {"successful": 1}}),
             clone=Mock(return_value={"acknowledged": True}),
@@ -139,6 +140,58 @@ def test_opensearch_index_create_combines_mappings_and_settings_under_body():
     )
 
 
+def test_opensearch_index_create_rewrites_unsupported_wildcard_mappings():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+    mappings = {
+        "properties": {
+            "result_key": {"type": "wildcard"},
+            "name": {"type": "keyword"},
+        },
+        "dynamic_templates": [
+            {
+                "metadata.*_wildcard_tpl": {
+                    "path_match": "metadata.*",
+                    "mapping": {"type": "wildcard", "copy_to": "__text__"},
+                }
+            }
+        ],
+    }
+
+    adapter.indices.create(index="alert_hot", mappings=mappings)
+
+    raw.indices.create.assert_called_once_with(
+        index="alert_hot",
+        body={
+            "mappings": {
+                "properties": {
+                    "result_key": {"type": "keyword"},
+                    "name": {"type": "keyword"},
+                },
+                "dynamic_templates": [
+                    {
+                        "metadata.*_wildcard_tpl": {
+                            "path_match": "metadata.*",
+                            "mapping": {"type": "keyword", "copy_to": "__text__"},
+                        }
+                    }
+                ],
+            }
+        },
+    )
+    assert mappings["properties"]["result_key"]["type"] == "wildcard"
+    assert mappings["dynamic_templates"][0]["metadata.*_wildcard_tpl"]["mapping"]["type"] == "wildcard"
+
+
+def test_opensearch_indices_get_is_supported_for_mapping_validation():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    adapter.indices.get(index="alert")
+
+    raw.indices.get.assert_called_once_with(index="alert")
+
+
 def test_opensearch_search_translates_query_structure_to_body():
     raw = make_raw_client()
     adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
@@ -169,13 +222,14 @@ def test_opensearch_search_translates_query_structure_to_body():
 def test_opensearch_pit_search_translates_paging_fields_to_body():
     raw = make_raw_client()
     adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+    sort = [{"_shard_doc": "desc"}]
 
     adapter.search(
         pit={"id": "os-pit", "keep_alive": "1m"},
         query={"match_all": {}},
         search_after=[10, "doc"],
         size=100,
-        sort=[{"_shard_doc": "desc"}],
+        sort=sort,
         _source=["id", "event"],
     )
 
@@ -185,10 +239,11 @@ def test_opensearch_pit_search_translates_paging_fields_to_body():
             "query": {"match_all": {}},
             "search_after": [10, "doc"],
             "size": 100,
-            "sort": [{"_shard_doc": "desc"}],
+            "sort": [{"_doc": "desc"}],
             "_source": ["id", "event"],
         },
     )
+    assert sort == [{"_shard_doc": "desc"}]
 
 
 def test_opensearch_pit_open_call_translates_to_create_pit_api():

--- a/test/test_datastore_compat.py
+++ b/test/test_datastore_compat.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from unittest.mock import Mock
+from urllib.error import HTTPError, URLError
 
 import elasticsearch
 import pytest
@@ -10,10 +11,16 @@ from assemblyline.datastore.collection import ESCollection
 from assemblyline.datastore.compat import (
     SearchBackend,
     SearchBackendCompatibilityError,
+    SearchBackendAmbiguousResponseError,
+    SearchBackendAuthenticationError,
+    SearchBackendConnectionError,
     SearchBackendException,
+    SearchBackendMalformedResponseError,
     SearchClientAdapter,
+    UnsupportedSearchBackendError,
     UnsupportedSearchBackendOperation,
     create_search_client,
+    detect_search_backend,
 )
 from assemblyline.datastore.exceptions import DataStoreException, UnsupportedElasticVersion, VersionConflictException
 from assemblyline.datastore.store import ESStore
@@ -70,6 +77,89 @@ def make_store_client(version_number, distribution=None):
     raw.info.return_value = {"version": version_info}
     backend = SearchBackend.OPENSEARCH if distribution == "opensearch" else SearchBackend.ELASTICSEARCH
     return SearchClientAdapter(raw, backend)
+
+
+def make_detection_response(payload, headers=None):
+    response = Mock()
+    response.headers = headers or {}
+    response.read.return_value = payload
+    response.__enter__ = Mock(return_value=response)
+    response.__exit__ = Mock(return_value=False)
+    return response
+
+
+def test_auto_detects_elasticsearch_from_product_header(monkeypatch):
+    response = make_detection_response(b'{"version":{"number":"8.10.2"}}',
+                                       {"X-Elastic-Product": "Elasticsearch"})
+    request = Mock(return_value=response)
+    monkeypatch.setattr("assemblyline.datastore.compat.urlopen", request)
+
+    backend = detect_search_backend(
+        ["http://service:secret@elastic:9200"], request_timeout=4, ca_certs=None, verify_certs=True)
+
+    assert backend == SearchBackend.ELASTICSEARCH
+    assert request.call_count == 1
+    sent_request = request.call_args.args[0]
+    assert sent_request.full_url == "http://elastic:9200/"
+    assert sent_request.get_header("Authorization").startswith("Basic ")
+
+
+def test_auto_detects_opensearch_from_distribution(monkeypatch):
+    response = make_detection_response(b'{"version":{"number":"2.12.0","distribution":"opensearch"}}')
+    monkeypatch.setattr("assemblyline.datastore.compat.urlopen", Mock(return_value=response))
+
+    assert detect_search_backend(
+        ["http://opensearch:9200"], request_timeout=4, ca_certs=None,
+        verify_certs=False) == SearchBackend.OPENSEARCH
+
+
+def test_auto_detection_rejects_ambiguous_response(monkeypatch):
+    response = make_detection_response(
+        b'{"version":{"distribution":"opensearch"}}', {"X-Elastic-Product": "Elasticsearch"})
+    monkeypatch.setattr("assemblyline.datastore.compat.urlopen", Mock(return_value=response))
+
+    with pytest.raises(SearchBackendAmbiguousResponseError, match="conflicting"):
+        detect_search_backend(["http://search:9200"], request_timeout=4, ca_certs=None, verify_certs=True)
+
+
+def test_auto_detection_rejects_unsupported_response(monkeypatch):
+    monkeypatch.setattr(
+        "assemblyline.datastore.compat.urlopen",
+        Mock(return_value=make_detection_response(b'{"version":{"number":"1.0"}}')))
+
+    with pytest.raises(UnsupportedSearchBackendError, match="no supported"):
+        detect_search_backend(["http://search:9200"], request_timeout=4, ca_certs=None, verify_certs=True)
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_auto_detection_reports_authentication_failure(monkeypatch, status):
+    monkeypatch.setattr(
+        "assemblyline.datastore.compat.urlopen",
+        Mock(side_effect=HTTPError("http://redacted/", status, "denied", {}, None)))
+
+    with pytest.raises(SearchBackendAuthenticationError, match=f"status {status}") as exc:
+        detect_search_backend(
+            ["http://service:secret@search:9200"], request_timeout=4, ca_certs=None, verify_certs=True)
+    assert "secret" not in str(exc.value)
+
+
+def test_auto_detection_reports_connection_failure_without_host_details(monkeypatch):
+    monkeypatch.setattr("assemblyline.datastore.compat.urlopen", Mock(side_effect=URLError("secret details")))
+
+    with pytest.raises(SearchBackendConnectionError) as exc:
+        detect_search_backend(
+            ["http://service:secret@search:9200"], request_timeout=4, ca_certs=None, verify_certs=True)
+    assert "secret" not in str(exc.value)
+    assert "search:9200" not in str(exc.value)
+
+
+def test_auto_detection_reports_malformed_json(monkeypatch):
+    monkeypatch.setattr(
+        "assemblyline.datastore.compat.urlopen",
+        Mock(return_value=make_detection_response(b'not-json')))
+
+    with pytest.raises(SearchBackendMalformedResponseError, match="malformed JSON"):
+        detect_search_backend(["http://search:9200"], request_timeout=4, ca_certs=None, verify_certs=True)
 
 
 def test_elasticsearch_adapter_preserves_es8_keywords():
@@ -685,6 +775,48 @@ def test_store_elasticsearch_version_validation_keeps_existing_minimum(monkeypat
     assert factory.call_args.args[0] == SearchBackend.ELASTICSEARCH
 
 
+@pytest.mark.parametrize("backend", [SearchBackend.ELASTICSEARCH, SearchBackend.OPENSEARCH])
+def test_store_explicit_backend_bypasses_detection(monkeypatch, backend):
+    distribution = "opensearch" if backend == SearchBackend.OPENSEARCH else None
+    version_number = "2.12.0" if distribution else "8.10.2"
+    detector = Mock()
+    monkeypatch.setattr("assemblyline.datastore.store.detect_search_backend", detector)
+    monkeypatch.setattr(
+        "assemblyline.datastore.store.create_search_client",
+        Mock(return_value=make_store_client(version_number, distribution=distribution)),
+    )
+
+    store = ESStore(["http://search:9200"], backend=backend)
+
+    assert store.backend == backend
+    detector.assert_not_called()
+
+
+def test_store_auto_detection_runs_once_and_reuses_concrete_backend(monkeypatch):
+    detector = Mock(return_value=SearchBackend.OPENSEARCH)
+    client = make_store_client("2.12.0", distribution="opensearch")
+    factory = Mock(return_value=client)
+    monkeypatch.setattr("assemblyline.datastore.store.detect_search_backend", detector)
+    monkeypatch.setattr("assemblyline.datastore.store.create_search_client", factory)
+
+    store = ESStore(["http://opensearch:9200"], backend="auto")
+    store.client.indices.create(index="alert", mappings={"properties": {"value": {"type": "wildcard"}}})
+    store.client.open_point_in_time(index="alert", keep_alive="1m")
+    store.client.tasks.get(task_id="node:1", wait_for_completion=True)
+    store.client.indices.clear_cache(index="alert")
+    store.connection_reset()
+
+    assert store.backend == SearchBackend.OPENSEARCH
+    detector.assert_called_once()
+    assert factory.call_count == 2
+    assert all(call.args[0] == SearchBackend.OPENSEARCH for call in factory.call_args_list)
+    client.raw_client.indices.create.assert_called_once_with(
+        index="alert", body={"mappings": {"properties": {"value": {"type": "keyword"}}}})
+    client.raw_client.create_pit.assert_called_once()
+    client.raw_client.tasks.get.assert_called_once()
+    client.raw_client.indices.clear_cache.assert_called_once()
+
+
 def test_store_elasticsearch_rejects_unsupported_version(monkeypatch):
     monkeypatch.setattr(
         "assemblyline.datastore.store.create_search_client",
@@ -784,6 +916,25 @@ def test_forge_get_datastore_uses_explicit_opensearch(monkeypatch):
     assert created[0][0] == ["http://opensearch:9200"]
     assert created[0][1] == "opensearch"
     assert created[0][2] is True
+
+
+def test_forge_get_datastore_passes_auto_to_store_for_single_resolution(monkeypatch):
+    config_data = Config().as_primitives()
+    config_data["datastore"]["type"] = "auto"
+    created = []
+
+    class FakeStore:
+        def __init__(self, hosts, backend, archive_access=False, archive_alernate_dtl=0):
+            created.append((hosts, backend))
+
+        def register(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr("assemblyline.datastore.store.ESStore", FakeStore)
+
+    forge.get_datastore(config=Config(config_data))
+
+    assert created[0][1] == "auto"
 
 
 def test_unexpected_backend_exception_is_not_ignored():

--- a/test/test_datastore_compat.py
+++ b/test/test_datastore_compat.py
@@ -1,0 +1,263 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import elasticsearch
+import pytest
+from elastic_transport import ApiResponseMeta, NodeConfig
+
+from assemblyline.datastore.collection import ESCollection
+from assemblyline.datastore.compat import (
+    SearchBackend,
+    SearchBackendException,
+    SearchClientAdapter,
+    UnsupportedSearchBackendOperation,
+)
+from assemblyline.datastore.exceptions import VersionConflictException
+from assemblyline.datastore.store import ESStore
+
+
+def make_response_meta(status):
+    return ApiResponseMeta(status, "1.1", {}, 0.0, NodeConfig("http", "localhost", 9200))
+
+
+def make_raw_client():
+    return SimpleNamespace(
+        bulk=Mock(return_value={"errors": False}),
+        close=Mock(),
+        delete=Mock(return_value={"result": "deleted"}),
+        exists=Mock(return_value=True),
+        get=Mock(return_value={"_id": "id", "_source": {"id": "id"}}),
+        index=Mock(return_value={"result": "created"}),
+        info=Mock(return_value={"version": {"number": "8.10.2"}}),
+        mget=Mock(return_value={"docs": []}),
+        ping=Mock(return_value=True),
+        search=Mock(return_value={"hits": {"hits": []}}),
+        update=Mock(return_value={"result": "updated"}),
+        cat=SimpleNamespace(nodes=Mock()),
+        cluster=SimpleNamespace(health=Mock()),
+        ilm=SimpleNamespace(get_lifecycle=Mock()),
+        indices=SimpleNamespace(
+            clear_cache=Mock(return_value={"_shards": {"successful": 1}}),
+            create=Mock(return_value={"acknowledged": True}),
+            exists=Mock(return_value=True),
+            exists_alias=Mock(return_value=False),
+            put_alias=Mock(return_value={"acknowledged": True}),
+            refresh=Mock(return_value={"_shards": {"successful": 1}}),
+            clone=Mock(return_value={"acknowledged": True}),
+        ),
+        nodes=SimpleNamespace(stats=Mock()),
+        security=SimpleNamespace(put_role=Mock(), put_user=Mock()),
+        tasks=SimpleNamespace(get=Mock()),
+    )
+
+
+def test_elasticsearch_adapter_preserves_es8_keywords():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.ELASTICSEARCH)
+
+    adapter.indices.create(index="alert_hot", mappings={"properties": {}}, settings={"index": {"number_of_shards": 1}})
+    raw.indices.create.assert_called_once_with(
+        index="alert_hot",
+        mappings={"properties": {}},
+        settings={"index": {"number_of_shards": 1}},
+    )
+
+    adapter.index(index="alert", id="1", document='{"id": "1"}', op_type="index")
+    raw.index.assert_called_once_with(index="alert", id="1", document='{"id": "1"}', op_type="index")
+
+    adapter.bulk(operations='{"delete": {"_id": "1"}}')
+    raw.bulk.assert_called_once_with(operations='{"delete": {"_id": "1"}}')
+
+    adapter.mget(index="alert", ids=["1", "2"])
+    raw.mget.assert_called_once_with(index="alert", ids=["1", "2"])
+
+    adapter.search(index="alert", query={"match_all": {}}, from_=1, size=10)
+    raw.search.assert_called_once_with(index="alert", query={"match_all": {}}, from_=1, size=10)
+
+
+def test_opensearch_index_document_translates_to_body():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    adapter.index(index="alert", id="1", document='{"id": "1"}', op_type="index")
+
+    raw.index.assert_called_once_with(index="alert", id="1", body='{"id": "1"}', op_type="index")
+
+
+def test_opensearch_bulk_translates_operations_to_body():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    adapter.bulk(operations='{"create": {"_id": "1"}}')
+
+    raw.bulk.assert_called_once_with(body='{"create": {"_id": "1"}}')
+
+
+def test_opensearch_mget_ids_translates_to_body():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    adapter.mget(index="alert", ids=["1", "2"])
+
+    raw.mget.assert_called_once_with(index="alert", body={"ids": ["1", "2"]})
+
+
+def test_opensearch_index_create_combines_mappings_and_settings_under_body():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    adapter.indices.create(index="alert_hot", mappings={"properties": {}}, settings={"index": {"number_of_shards": 1}})
+
+    raw.indices.create.assert_called_once_with(
+        index="alert_hot",
+        body={"mappings": {"properties": {}}, "settings": {"index": {"number_of_shards": 1}}},
+    )
+
+
+def test_opensearch_search_translates_query_structure_to_body():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    adapter.search(
+        index="alert",
+        query={"query_string": {"query": "id:*"}},
+        from_=2,
+        size=25,
+        sort=[{"id": "asc"}],
+        _source=["id"],
+        track_total_hits=True,
+    )
+
+    raw.search.assert_called_once_with(
+        index="alert",
+        track_total_hits=True,
+        body={
+            "query": {"query_string": {"query": "id:*"}},
+            "from": 2,
+            "size": 25,
+            "sort": [{"id": "asc"}],
+            "_source": ["id"],
+        },
+    )
+
+
+def test_opensearch_update_translates_script_to_body():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    adapter.update(index="alert", id="1", script={"source": "ctx._source.count += 1"}, retry_on_conflict=3)
+
+    raw.update.assert_called_once_with(
+        index="alert",
+        id="1",
+        body={"script": {"source": "ctx._source.count += 1"}},
+        retry_on_conflict=3,
+    )
+
+
+def test_exceptions_normalize_to_status_and_internal_type():
+    original = Exception("missing")
+    original.status_code = 404
+
+    normalized = SearchClientAdapter.normalize_exception(original)
+
+    assert isinstance(normalized, SearchBackendException)
+    assert normalized.status_code == 404
+    assert normalized.message == "missing"
+    assert normalized.original is original
+
+
+def test_opensearch_client_exceptions_are_wrapped():
+    raw = make_raw_client()
+    original = Exception("too busy")
+    original.status_code = 429
+    raw.search.side_effect = original
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    with pytest.raises(SearchBackendException) as exc:
+        adapter.search(index="alert", query={"match_all": {}})
+
+    assert exc.value.status_code == 429
+    assert exc.value.original is original
+
+
+def test_unsupported_opensearch_operations_fail_clearly():
+    adapter = SearchClientAdapter(make_raw_client(), SearchBackend.OPENSEARCH)
+
+    with pytest.raises(UnsupportedSearchBackendOperation):
+        adapter.indices.delete(index="alert")
+
+    with pytest.raises(UnsupportedSearchBackendOperation):
+        adapter.cluster.health()
+
+    with pytest.raises(UnsupportedSearchBackendOperation):
+        adapter.search(index="alert", pit={"id": "pit"}, search_after=[1])
+
+
+def test_elasticsearch_delegates_existing_unsupported_operation_to_raw_client():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.ELASTICSEARCH)
+
+    adapter.indices.clear_cache(index="alert")
+
+    raw.indices.clear_cache.assert_called_once_with(index="alert")
+
+
+def test_opensearch_rejects_same_unsupported_operation_clearly():
+    adapter = SearchClientAdapter(make_raw_client(), SearchBackend.OPENSEARCH)
+
+    with pytest.raises(UnsupportedSearchBackendOperation, match="indices.clear_cache"):
+        adapter.indices.clear_cache(index="alert")
+
+
+def test_elasticsearch_adapter_preserves_not_found_exception():
+    raw = make_raw_client()
+    not_found = elasticsearch.NotFoundError("missing", make_response_meta(404), {"error": {"type": "not_found"}})
+    raw.get.side_effect = not_found
+    adapter = SearchClientAdapter(raw, SearchBackend.ELASTICSEARCH)
+
+    with pytest.raises(elasticsearch.NotFoundError) as exc:
+        adapter.get(index="alert", id="missing")
+
+    assert exc.value is not_found
+
+
+def test_elasticsearch_conflict_status_extraction_and_retry_exception():
+    conflict = elasticsearch.ConflictError("conflict", make_response_meta(409), {"updated": 2, "deleted": 1})
+    store = object.__new__(ESStore)
+
+    assert SearchClientAdapter.get_exception_status(conflict) == 409
+    with pytest.raises(VersionConflictException):
+        store.with_retries(Mock(side_effect=conflict), index="alert", raise_conflicts=True)
+
+
+def test_opensearch_normalized_status_extraction():
+    original = Exception("conflict")
+    original.status_code = 409
+
+    normalized = SearchClientAdapter.normalize_exception(original)
+
+    assert SearchClientAdapter.get_exception_status(normalized) == 409
+    assert normalized.status_code == 409
+
+
+def test_unexpected_backend_exception_is_not_ignored():
+    store = object.__new__(ESStore)
+    unexpected = SearchBackendException("unexpected", status_code=500)
+
+    with pytest.raises(SearchBackendException) as exc:
+        store.with_retries(Mock(side_effect=unexpected), index="alert")
+
+    assert exc.value is unexpected
+
+
+def test_collection_update_does_not_ignore_unexpected_backend_exception():
+    collection = object.__new__(ESCollection)
+    collection._validate_operations = Mock(return_value=[])
+    collection._create_scripts_from_operations = Mock(return_value={"source": "ctx._source.count += 1"})
+    collection.get_index_list = Mock(return_value=["alert"])
+    collection.datastore = SimpleNamespace(client=SimpleNamespace(update=Mock()))
+    collection.with_retries = Mock(side_effect=SearchBackendException("unexpected", status_code=500))
+
+    with pytest.raises(SearchBackendException):
+        collection.update("missing", [], index_type=None)

--- a/test/test_datastore_compat.py
+++ b/test/test_datastore_compat.py
@@ -15,7 +15,7 @@ from assemblyline.datastore.compat import (
     UnsupportedSearchBackendOperation,
     create_search_client,
 )
-from assemblyline.datastore.exceptions import UnsupportedElasticVersion, VersionConflictException
+from assemblyline.datastore.exceptions import DataStoreException, UnsupportedElasticVersion, VersionConflictException
 from assemblyline.datastore.store import ESStore
 from assemblyline.odm.models.config import Config
 
@@ -29,6 +29,7 @@ def make_raw_client():
         bulk=Mock(return_value={"errors": False}),
         close=Mock(),
         delete=Mock(return_value={"result": "deleted"}),
+        delete_by_query=Mock(return_value={"task": "node:1"}),
         exists=Mock(return_value=True),
         get=Mock(return_value={"_id": "id", "_source": {"id": "id"}}),
         index=Mock(return_value={"result": "created"}),
@@ -38,6 +39,7 @@ def make_raw_client():
         ping=Mock(return_value=True),
         search=Mock(return_value={"hits": {"hits": []}}),
         update=Mock(return_value={"result": "updated"}),
+        update_by_query=Mock(return_value={"task": "node:2"}),
         close_point_in_time=Mock(return_value={"succeeded": True, "num_freed": 1}),
         create_pit=Mock(return_value={"pit_id": "os-pit"}),
         delete_pit=Mock(return_value={"pits": [{"pit_id": "os-pit", "successful": True}]}),
@@ -56,7 +58,7 @@ def make_raw_client():
         ),
         nodes=SimpleNamespace(stats=Mock()),
         security=SimpleNamespace(put_role=Mock(), put_user=Mock()),
-        tasks=SimpleNamespace(get=Mock()),
+        tasks=SimpleNamespace(get=Mock(return_value={"completed": True, "response": {"updated": 1}})),
     )
 
 
@@ -92,6 +94,43 @@ def test_elasticsearch_adapter_preserves_es8_keywords():
 
     adapter.search(index="alert", query={"match_all": {}}, from_=1, size=10)
     raw.search.assert_called_once_with(index="alert", query={"match_all": {}}, from_=1, size=10)
+
+    adapter.delete_by_query(
+        index="alert",
+        query={"match_all": {}},
+        wait_for_completion=False,
+        conflicts="proceed",
+        sort="id:asc",
+        max_docs=10,
+    )
+    raw.delete_by_query.assert_called_once_with(
+        index="alert",
+        query={"match_all": {}},
+        wait_for_completion=False,
+        conflicts="proceed",
+        sort="id:asc",
+        max_docs=10,
+    )
+
+    adapter.update_by_query(
+        index="alert",
+        query={"match_all": {}},
+        script={"source": "ctx._source.count += 1"},
+        wait_for_completion=False,
+        conflicts="proceed",
+        max_docs=10,
+    )
+    raw.update_by_query.assert_called_once_with(
+        index="alert",
+        query={"match_all": {}},
+        script={"source": "ctx._source.count += 1"},
+        wait_for_completion=False,
+        conflicts="proceed",
+        max_docs=10,
+    )
+
+    adapter.tasks.get(task_id="node:1", wait_for_completion=True, timeout="5s")
+    raw.tasks.get.assert_called_once_with(task_id="node:1", wait_for_completion=True, timeout="5s")
 
 
 def test_elasticsearch_pit_open_call_is_forwarded_unchanged():
@@ -350,6 +389,117 @@ def test_opensearch_update_translates_script_to_body():
     )
 
 
+def test_opensearch_delete_by_query_translates_query_and_supported_params():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    response = adapter.delete_by_query(
+        index="alert",
+        query={"term": {"workflow_id": "wf1"}},
+        wait_for_completion=False,
+        conflicts="proceed",
+        sort="id:asc",
+        max_docs=5,
+    )
+
+    assert response == {"task": "node:1"}
+    raw.delete_by_query.assert_called_once_with(
+        index="alert",
+        body={"query": {"term": {"workflow_id": "wf1"}}, "max_docs": 5},
+        params={"wait_for_completion": "false", "conflicts": "proceed", "sort": "id:asc"},
+    )
+
+
+def test_opensearch_update_by_query_translates_query_script_and_supported_params():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    response = adapter.update_by_query(
+        index="alert",
+        query={"term": {"workflow_id": "wf1"}},
+        script={"source": "ctx._source.workflow_completed = true", "lang": "painless"},
+        wait_for_completion=False,
+        conflicts="proceed",
+        max_docs=5,
+    )
+
+    assert response == {"task": "node:2"}
+    raw.update_by_query.assert_called_once_with(
+        index="alert",
+        body={
+            "query": {"term": {"workflow_id": "wf1"}},
+            "script": {"source": "ctx._source.workflow_completed = true", "lang": "painless"},
+            "max_docs": 5,
+        },
+        params={"wait_for_completion": "false", "conflicts": "proceed"},
+    )
+
+
+def test_opensearch_tasks_get_translates_params_and_preserves_response():
+    raw = make_raw_client()
+    raw.tasks.get.return_value = {
+        "completed": True,
+        "response": {"deleted": 2, "version_conflicts": 1},
+    }
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    response = adapter.tasks.get(task_id="node:1", wait_for_completion=True, timeout="5s")
+
+    assert response["response"]["deleted"] == 2
+    assert response["response"]["version_conflicts"] == 1
+    raw.tasks.get.assert_called_once_with(
+        task_id="node:1",
+        params={"wait_for_completion": "true"},
+    )
+
+
+def test_opensearch_tasks_get_preserves_task_errors():
+    raw = make_raw_client()
+    raw.tasks.get.return_value = {"completed": True, "error": {"type": "script_exception", "reason": "compile error"}}
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    response = adapter.tasks.get(task_id="node:1", wait_for_completion=True)
+
+    assert response["error"]["type"] == "script_exception"
+
+
+def test_opensearch_query_task_exceptions_are_wrapped():
+    raw = make_raw_client()
+    original = Exception("query task failed")
+    original.status_code = 400
+    raw.update_by_query.side_effect = original
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    with pytest.raises(SearchBackendException) as exc:
+        adapter.update_by_query(index="alert", query={"match_all": {}})
+
+    assert exc.value.status_code == 400
+    assert exc.value.original is original
+
+
+def test_opensearch_query_task_duplicate_body_fields_fail_clearly():
+    adapter = SearchClientAdapter(make_raw_client(), SearchBackend.OPENSEARCH)
+
+    with pytest.raises(SearchBackendCompatibilityError, match="query"):
+        adapter.delete_by_query(index="alert", body={"query": {"match_all": {}}}, query={"term": {"id": "1"}})
+
+    with pytest.raises(SearchBackendCompatibilityError, match="script"):
+        adapter.update_by_query(index="alert", body={"script": {"source": "ctx.op = 'noop'"}}, script={"source": ""})
+
+
+def test_opensearch_query_task_unsupported_arguments_fail_clearly():
+    adapter = SearchClientAdapter(make_raw_client(), SearchBackend.OPENSEARCH)
+
+    with pytest.raises(SearchBackendCompatibilityError, match="unsupported"):
+        adapter.delete_by_query(index="alert", query={"match_all": {}}, unsupported=True)
+
+    with pytest.raises(SearchBackendCompatibilityError, match="unsupported"):
+        adapter.update_by_query(index="alert", query={"match_all": {}}, script={}, unsupported=True)
+
+    with pytest.raises(SearchBackendCompatibilityError, match="unsupported"):
+        adapter.tasks.get(task_id="node:1", unsupported=True)
+
+
 def test_exceptions_normalize_to_status_and_internal_type():
     original = Exception("missing")
     original.status_code = 404
@@ -389,10 +539,7 @@ def test_unsupported_opensearch_operations_fail_clearly():
         (lambda: adapter.security.put_role(name="role"), "security.put_role"),
         (lambda: adapter.security.put_user(username="user"), "security.put_user"),
         (lambda: adapter.ilm.get_lifecycle(name="policy"), "ilm.get_lifecycle"),
-        (lambda: adapter.delete_by_query(index="alert", query={"match_all": {}}), "delete_by_query"),
-        (lambda: adapter.update_by_query(index="alert", query={"match_all": {}}), "update_by_query"),
         (lambda: adapter.reindex(source={"index": "old"}, dest={"index": "new"}), "reindex"),
-        (lambda: adapter.tasks.get(task_id="task"), "tasks.get"),
         (lambda: adapter.indices.clone(index="old", target="new"), "indices.clone"),
         (lambda: adapter.indices.split(index="old", target="new"), "indices.split"),
         (lambda: adapter.indices.shrink(index="old", target="new"), "indices.shrink"),
@@ -465,6 +612,18 @@ def test_opensearch_normalized_status_extraction():
 
     assert SearchClientAdapter.get_exception_status(normalized) == 409
     assert normalized.status_code == 409
+
+
+def test_store_task_wait_raises_task_error():
+    store = object.__new__(ESStore)
+    store.client = SimpleNamespace(tasks=SimpleNamespace(get=Mock()))
+    store.with_retries = Mock(return_value={
+        "completed": True,
+        "error": {"type": "script_exception", "reason": "compile error"},
+    })
+
+    with pytest.raises(DataStoreException, match="compile error"):
+        store._get_task_results({"task": "node:1"})
 
 
 def test_create_search_client_selects_elasticsearch_client(monkeypatch):

--- a/test/test_datastore_compat.py
+++ b/test/test_datastore_compat.py
@@ -414,11 +414,26 @@ def test_elasticsearch_delegates_existing_unsupported_operation_to_raw_client():
     raw.indices.clear_cache.assert_called_once_with(index="alert")
 
 
-def test_opensearch_rejects_same_unsupported_operation_clearly():
-    adapter = SearchClientAdapter(make_raw_client(), SearchBackend.OPENSEARCH)
+def test_opensearch_indices_clear_cache_delegates_basic_commit_call():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
 
-    with pytest.raises(UnsupportedSearchBackendOperation, match="indices.clear_cache"):
-        adapter.indices.clear_cache(index="alert")
+    response = adapter.indices.clear_cache(index="alert")
+
+    assert response == {"_shards": {"successful": 1}}
+    raw.indices.clear_cache.assert_called_once_with(index="alert")
+
+
+def test_opensearch_indices_clear_cache_moves_supported_flags_to_params():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    adapter.indices.clear_cache(index="alert", fielddata=True, fields="id", request=True)
+
+    raw.indices.clear_cache.assert_called_once_with(
+        index="alert",
+        params={"fielddata": True, "fields": "id", "request": True},
+    )
 
 
 def test_elasticsearch_adapter_preserves_not_found_exception():

--- a/test/test_datastore_compat.py
+++ b/test/test_datastore_compat.py
@@ -5,6 +5,7 @@ import elasticsearch
 import pytest
 from elastic_transport import ApiResponseMeta, NodeConfig
 
+from assemblyline.common import forge
 from assemblyline.datastore.collection import ESCollection
 from assemblyline.datastore.compat import (
     SearchBackend,
@@ -12,9 +13,11 @@ from assemblyline.datastore.compat import (
     SearchBackendException,
     SearchClientAdapter,
     UnsupportedSearchBackendOperation,
+    create_search_client,
 )
-from assemblyline.datastore.exceptions import VersionConflictException
+from assemblyline.datastore.exceptions import UnsupportedElasticVersion, VersionConflictException
 from assemblyline.datastore.store import ESStore
+from assemblyline.odm.models.config import Config
 
 
 def make_response_meta(status):
@@ -55,6 +58,16 @@ def make_raw_client():
         security=SimpleNamespace(put_role=Mock(), put_user=Mock()),
         tasks=SimpleNamespace(get=Mock()),
     )
+
+
+def make_store_client(version_number, distribution=None):
+    version_info = {"number": version_number}
+    if distribution is not None:
+        version_info["distribution"] = distribution
+    raw = make_raw_client()
+    raw.info.return_value = {"version": version_info}
+    backend = SearchBackend.OPENSEARCH if distribution == "opensearch" else SearchBackend.ELASTICSEARCH
+    return SearchClientAdapter(raw, backend)
 
 
 def test_elasticsearch_adapter_preserves_es8_keywords():
@@ -246,6 +259,28 @@ def test_opensearch_pit_search_translates_paging_fields_to_body():
     assert sort == [{"_shard_doc": "desc"}]
 
 
+def test_opensearch_search_omits_null_body_fields():
+    raw = make_raw_client()
+    adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
+
+    adapter.search(
+        pit={"id": "os-pit", "keep_alive": "1m"},
+        query={"match_all": {}},
+        search_after=None,
+        from_=0,
+        size=100,
+    )
+
+    raw.search.assert_called_once_with(
+        body={
+            "pit": {"id": "os-pit", "keep_alive": "1m"},
+            "query": {"match_all": {}},
+            "from": 0,
+            "size": 100,
+        },
+    )
+
+
 def test_opensearch_pit_open_call_translates_to_create_pit_api():
     raw = make_raw_client()
     adapter = SearchClientAdapter(raw, SearchBackend.OPENSEARCH)
@@ -344,11 +379,30 @@ def test_opensearch_client_exceptions_are_wrapped():
 def test_unsupported_opensearch_operations_fail_clearly():
     adapter = SearchClientAdapter(make_raw_client(), SearchBackend.OPENSEARCH)
 
-    with pytest.raises(UnsupportedSearchBackendOperation):
+    with pytest.raises(UnsupportedSearchBackendOperation, match="indices.delete"):
         adapter.indices.delete(index="alert")
 
-    with pytest.raises(UnsupportedSearchBackendOperation):
+    with pytest.raises(UnsupportedSearchBackendOperation, match="cluster.health"):
         adapter.cluster.health()
+
+    unsupported_calls = [
+        (lambda: adapter.security.put_role(name="role"), "security.put_role"),
+        (lambda: adapter.security.put_user(username="user"), "security.put_user"),
+        (lambda: adapter.ilm.get_lifecycle(name="policy"), "ilm.get_lifecycle"),
+        (lambda: adapter.delete_by_query(index="alert", query={"match_all": {}}), "delete_by_query"),
+        (lambda: adapter.update_by_query(index="alert", query={"match_all": {}}), "update_by_query"),
+        (lambda: adapter.reindex(source={"index": "old"}, dest={"index": "new"}), "reindex"),
+        (lambda: adapter.tasks.get(task_id="task"), "tasks.get"),
+        (lambda: adapter.indices.clone(index="old", target="new"), "indices.clone"),
+        (lambda: adapter.indices.split(index="old", target="new"), "indices.split"),
+        (lambda: adapter.indices.shrink(index="old", target="new"), "indices.shrink"),
+        (lambda: adapter.indices.exists_template(name="template"), "indices.exists_template"),
+        (lambda: adapter.indices.delete_template(name="template"), "indices.delete_template"),
+    ]
+
+    for operation, message in unsupported_calls:
+        with pytest.raises(UnsupportedSearchBackendOperation, match=message):
+            operation()
 
 
 def test_elasticsearch_delegates_existing_unsupported_operation_to_raw_client():
@@ -396,6 +450,149 @@ def test_opensearch_normalized_status_extraction():
 
     assert SearchClientAdapter.get_exception_status(normalized) == 409
     assert normalized.status_code == 409
+
+
+def test_create_search_client_selects_elasticsearch_client(monkeypatch):
+    client_class = Mock(return_value=make_raw_client())
+    monkeypatch.setattr("assemblyline.datastore.compat.elasticsearch.Elasticsearch", client_class)
+
+    adapter = create_search_client(
+        SearchBackend.ELASTICSEARCH,
+        ["http://elastic:9200"],
+        max_retries=3,
+        request_timeout=30,
+        ca_certs="/tmp/ca.pem",
+        verify_certs=True,
+    )
+
+    assert adapter.backend == SearchBackend.ELASTICSEARCH
+    client_class.assert_called_once_with(
+        hosts=["http://elastic:9200"],
+        max_retries=3,
+        request_timeout=30,
+        ca_certs="/tmp/ca.pem",
+        verify_certs=True,
+    )
+
+
+def test_create_search_client_selects_opensearch_client(monkeypatch):
+    client_class = Mock(return_value=make_raw_client())
+    monkeypatch.setattr("assemblyline.datastore.compat._load_opensearch_client", Mock(return_value=client_class))
+
+    adapter = create_search_client(
+        SearchBackend.OPENSEARCH,
+        ["http://opensearch:9200"],
+        max_retries=2,
+        request_timeout=45,
+        ca_certs=None,
+        verify_certs=False,
+    )
+
+    assert adapter.backend == SearchBackend.OPENSEARCH
+    client_class.assert_called_once_with(
+        hosts=["http://opensearch:9200"],
+        max_retries=2,
+        timeout=45,
+        ca_certs=None,
+        verify_certs=False,
+    )
+
+
+def test_store_elasticsearch_version_validation_keeps_existing_minimum(monkeypatch):
+    client = make_store_client("8.10.2")
+    factory = Mock(return_value=client)
+    monkeypatch.setattr("assemblyline.datastore.store.create_search_client", factory)
+
+    store = ESStore(["http://elastic:9200"], backend=SearchBackend.ELASTICSEARCH)
+
+    assert store.backend == SearchBackend.ELASTICSEARCH
+    assert str(store.es_version) == "8.10.2"
+    factory.assert_called_once()
+    assert factory.call_args.args[0] == SearchBackend.ELASTICSEARCH
+
+
+def test_store_elasticsearch_rejects_unsupported_version(monkeypatch):
+    monkeypatch.setattr(
+        "assemblyline.datastore.store.create_search_client",
+        Mock(return_value=make_store_client("7.9.3")),
+    )
+
+    with pytest.raises(UnsupportedElasticVersion, match="Elastic version 7.9.3"):
+        ESStore(["http://elastic:9200"], backend=SearchBackend.ELASTICSEARCH)
+
+
+def test_store_opensearch_version_validation_uses_distribution(monkeypatch):
+    client = make_store_client("2.12.0", distribution="opensearch")
+    factory = Mock(return_value=client)
+    monkeypatch.setattr("assemblyline.datastore.store.create_search_client", factory)
+
+    store = ESStore(["http://opensearch:9200"], backend=SearchBackend.OPENSEARCH)
+
+    assert store.backend == SearchBackend.OPENSEARCH
+    assert str(store.es_version) == "2.12.0"
+    factory.assert_called_once()
+    assert factory.call_args.args[0] == SearchBackend.OPENSEARCH
+
+
+def test_store_opensearch_rejects_non_opensearch_product(monkeypatch):
+    monkeypatch.setattr(
+        "assemblyline.datastore.store.create_search_client",
+        Mock(return_value=make_store_client("8.10.2")),
+    )
+
+    with pytest.raises(UnsupportedElasticVersion, match="OpenSearch backend selected"):
+        ESStore(["http://elastic:9200"], backend=SearchBackend.OPENSEARCH)
+
+
+def test_store_opensearch_rejects_unsupported_version(monkeypatch):
+    monkeypatch.setattr(
+        "assemblyline.datastore.store.create_search_client",
+        Mock(return_value=make_store_client("2.11.1", distribution="opensearch")),
+    )
+
+    with pytest.raises(UnsupportedElasticVersion, match="OpenSearch version 2.11.1"):
+        ESStore(["http://opensearch:9200"], backend=SearchBackend.OPENSEARCH)
+
+
+def test_forge_get_datastore_defaults_to_elasticsearch(monkeypatch):
+    created = []
+
+    class FakeStore:
+        def __init__(self, hosts, backend, archive_access=False, archive_alernate_dtl=0):
+            created.append((hosts, backend, archive_access, archive_alernate_dtl))
+
+        def register(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr("assemblyline.datastore.store.ESStore", FakeStore)
+
+    datastore = forge.get_datastore(config=Config())
+
+    assert datastore.ds.__class__ is FakeStore
+    assert created[0][1] == "elasticsearch"
+
+
+def test_forge_get_datastore_uses_explicit_opensearch(monkeypatch):
+    config_data = Config().as_primitives()
+    config_data["datastore"]["type"] = "opensearch"
+    config_data["datastore"]["hosts"] = ["http://opensearch:9200"]
+    created = []
+
+    class FakeStore:
+        def __init__(self, hosts, backend, archive_access=False, archive_alernate_dtl=0):
+            created.append((hosts, backend, archive_access, archive_alernate_dtl))
+
+        def register(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr("assemblyline.datastore.store.ESStore", FakeStore)
+
+    datastore = forge.get_datastore(config=Config(config_data), archive_access=True)
+
+    assert datastore.ds.__class__ is FakeStore
+    assert created[0][0] == ["http://opensearch:9200"]
+    assert created[0][1] == "opensearch"
+    assert created[0][2] is True
 
 
 def test_unexpected_backend_exception_is_not_ignored():

--- a/test/test_datastore_opensearch.py
+++ b/test/test_datastore_opensearch.py
@@ -646,10 +646,12 @@ def test_opensearch_runtime_smoke_uses_factory_models_commit_pit_and_delete(requ
     search = file_collection.search("sha256:" + doc_id, rows=10, fl="id,sha256,type", as_obj=False,
                                     track_total_hits=True)
     assert search["total"] == 1
-    assert search["items"] == [{"id": doc_id, "sha256": doc_id, "type": "unknown"}]
+    assert search["items"][0]["id"] == doc_id
+    assert search["items"][0]["sha256"] == doc_id
+    assert search["items"][0]["type"] == "unknown"
 
     pit_page = file_collection.search("sha256:" + doc_id, rows=1, fl="id", as_obj=False, deep_paging_id="start")
-    assert pit_page["items"] == [{"id": doc_id}]
+    assert pit_page["items"][0]["id"] == doc_id
 
     assert file_collection.delete(doc_id)
     assert file_collection.commit()

--- a/test/test_datastore_opensearch.py
+++ b/test/test_datastore_opensearch.py
@@ -7,6 +7,7 @@ import pytest
 
 from assemblyline.common import forge
 from assemblyline.datastore.compat import SearchBackend, SearchBackendException
+from assemblyline.datastore.exceptions import DataStoreException
 from assemblyline.datastore.support.build import build_mapping
 from assemblyline.odm.models.config import Config
 from assemblyline.odm.models.alert import Alert
@@ -657,3 +658,99 @@ def test_opensearch_runtime_smoke_uses_factory_models_commit_pit_and_delete(requ
 
     datastore.ds.close()
     assert datastore.ds.is_closed()
+
+
+def _opensearch_datastore(request, collection_name):
+    host = os.environ.get('AL_TEST_OPENSEARCH_HOST', 'http://127.0.0.1:9201')
+    config_data = Config().as_primitives()
+    config_data["datastore"]["type"] = "opensearch"
+    config_data["datastore"]["hosts"] = [host]
+    config_data["datastore"]["archive"]["enabled"] = False
+
+    datastore = forge.get_datastore(config=Config(config_data))
+    datastore.ds.task_wait_timeout = 30
+
+    def cleanup():
+        try:
+            if datastore.ds.client:
+                datastore.ds.client.raw_client.indices.delete(index=f"{collection_name}*", ignore_unavailable=True)
+        finally:
+            if not datastore.ds.is_closed():
+                datastore.ds.close()
+
+    request.addfinalizer(cleanup)
+    datastore.ds.register(collection_name)
+    return datastore, datastore.ds.__getattr__(collection_name)
+
+
+def test_opensearch_delete_by_query_async_task_via_datastore(request):
+    collection_name = f"al_os_dbq_{uuid.uuid4().hex}"
+    datastore, collection = _opensearch_datastore(request, collection_name)
+
+    for doc_id, group in (("delete-1", "delete"), ("delete-2", "delete"), ("keep-1", "keep")):
+        assert collection.save(doc_id, {"group": group, "count": 1})
+    assert collection.commit()
+
+    deleted = collection.delete_by_query("group:delete")
+    assert deleted == 2
+    assert collection.commit()
+
+    remaining = collection.search("id:*", rows=10, fl="id,group", as_obj=False, track_total_hits=True)
+    assert remaining["total"] == 1
+    assert remaining["items"] == [{"id": "keep-1", "group": "keep"}]
+
+    task = datastore.ds.client.delete_by_query(
+        index=collection_name,
+        query={"term": {"group": "missing"}},
+        wait_for_completion=False,
+        conflicts="proceed",
+    )
+    task_response = datastore.ds._get_task_results(task)
+    assert task_response["deleted"] == 0
+    assert task_response["version_conflicts"] == 0
+
+
+def test_opensearch_update_by_query_async_task_and_ui_style_update(request):
+    collection_name = f"al_os_ubq_{uuid.uuid4().hex}"
+    _, collection = _opensearch_datastore(request, collection_name)
+
+    for doc_id, group in (("update-1", "update"), ("update-2", "update"), ("keep-1", "keep")):
+        assert collection.save(doc_id, {"group": group, "count": 1, "owner": "old"})
+    assert collection.commit()
+
+    updated = collection.update_by_query("group:update", [(collection.UPDATE_INC, "count", 4)])
+    assert updated == 2
+    assert collection.commit()
+
+    update_docs = collection.search("group:update", rows=10, fl="id,count,owner", as_obj=False, track_total_hits=True)
+    assert update_docs["total"] == 2
+    assert {item["count"] for item in update_docs["items"]} == {5}
+
+    keep_doc = collection.get("keep-1", as_obj=False)
+    assert keep_doc["count"] == 1
+    assert keep_doc["owner"] == "old"
+
+    ui_style_updated = collection.update_by_query(
+        "id:update-1",
+        [(collection.UPDATE_SET, "owner", "analyst")],
+        filters=["group:update"],
+    )
+    assert ui_style_updated == 1
+    assert collection.commit()
+    assert collection.get("update-1", as_obj=False)["owner"] == "analyst"
+    assert collection.get("update-2", as_obj=False)["owner"] == "old"
+
+
+def test_opensearch_update_by_query_task_failure_is_visible(request):
+    collection_name = f"al_os_ubq_fail_{uuid.uuid4().hex}"
+    _, collection = _opensearch_datastore(request, collection_name)
+
+    assert collection.save("bad-1", {"group": "bad", "count": 1})
+    assert collection.commit()
+
+    with pytest.raises(DataStoreException, match="failed"):
+        collection._update_async(
+            collection_name,
+            {"lang": "painless", "source": "ctx._source.count += "},
+            {"term": {"group": "bad"}},
+        )

--- a/test/test_datastore_opensearch.py
+++ b/test/test_datastore_opensearch.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 
 import pytest
 
+from assemblyline.datastore.compat import SearchBackendException
 from assemblyline.datastore.support.build import build_mapping
 from assemblyline.odm.models.alert import Alert
 from assemblyline.odm.models.result import Section
@@ -157,6 +158,10 @@ def _create_index(client, index, alias=None):
 def _refresh(client, index):
     response = client.indices.refresh(index=index)
     assert response["_shards"]["failed"] == 0
+
+
+def _hit_ids(response):
+    return [hit["_source"]["id"] for hit in response["hits"]["hits"]]
 
 
 def _sample_doc(doc_id, **overrides):
@@ -351,6 +356,115 @@ def test_opensearch_actual_metadata_and_safelisted_tag_behavior(opensearch_clien
     assert properties["metadata"]["properties"]["campaign"]["copy_to"] == ["__text__"]
     assert properties["metadata"]["properties"]["submitter_team"]["type"] == "keyword"
     assert properties["safelisted_tags"]["properties"]["network"]["properties"]["static"]["properties"]["ip"]["type"] == "keyword"
+
+
+def test_opensearch_metadata_keyword_translation_edge_cases(opensearch_client):
+    index = opensearch_client.make_index_name("metadata_edges")
+    _create_index(opensearch_client, index)
+
+    near_keyword_limit = "n" * 32766
+    doc = _sample_doc(
+        "doc-edge",
+        metadata={
+            "plain": "simple",
+            "mixed_case": "MiXeDCase",
+            "punctuation": "big-bad value",
+            "url": "https://example.com/a/b?x=1&token=Alpha",
+            "path": r"C:\Users\Alice\AppData\Local\Temp\payload.exe",
+            "command": "powershell.exe -NoProfile -EncodedCommand SQBFAFgA",
+            "unicode": "caf\u00e9 \u2603",
+            "long_257": "l" * 257,
+            "near_limit": near_keyword_limit,
+            "secondary": "Beta-2026",
+            "regex_value": "abbbc",
+        },
+    )
+    created = opensearch_client.index(index=index, id="doc-edge", document=json.dumps(doc), refresh=True)
+    assert created["result"] == "created"
+
+    fetched = opensearch_client.get(index=index, id="doc-edge")
+    assert fetched["_source"]["metadata"] == doc["metadata"]
+
+    assert _hit_ids(opensearch_client.search(
+        index=index,
+        query={"term": {"metadata.plain": "simple"}},
+        _source=["id"],
+    )) == ["doc-edge"]
+    assert _hit_ids(opensearch_client.search(
+        index=index,
+        query={"term": {"metadata.long_257": "l" * 257}},
+        _source=["id"],
+    )) == ["doc-edge"]
+    assert _hit_ids(opensearch_client.search(
+        index=index,
+        query={"term": {"metadata.near_limit": near_keyword_limit}},
+        _source=["id"],
+    )) == ["doc-edge"]
+    assert _hit_ids(opensearch_client.search(
+        index=index,
+        query={"wildcard": {"metadata.secondary": "*-2026"}},
+        _source=["id"],
+    )) == ["doc-edge"]
+    assert _hit_ids(opensearch_client.search(
+        index=index,
+        query={"wildcard": {"metadata.secondary": "Beta-*"}},
+        _source=["id"],
+    )) == ["doc-edge"]
+    assert _hit_ids(opensearch_client.search(
+        index=index,
+        query={"wildcard": {"metadata.url": "*example.com/a/b*"}},
+        _source=["id"],
+    )) == ["doc-edge"]
+    assert _hit_ids(opensearch_client.search(
+        index=index,
+        query={"query_string": {"query": r"metadata.punctuation:big\-bad\ value"}},
+        _source=["id"],
+    )) == ["doc-edge"]
+    assert _hit_ids(opensearch_client.search(
+        index=index,
+        query={"regexp": {"metadata.regex_value": "ab+c"}},
+        _source=["id"],
+    )) == ["doc-edge"]
+    assert _hit_ids(opensearch_client.search(
+        index=index,
+        query={"exists": {"field": "metadata.command"}},
+        _source=["id"],
+    )) == ["doc-edge"]
+    assert _hit_ids(opensearch_client.search(
+        index=index,
+        query={"query_string": {"default_field": "__text__", "query": "EncodedCommand"}},
+        _source=["id"],
+    )) == ["doc-edge"]
+
+    assert opensearch_client.search(
+        index=index,
+        query={"term": {"metadata.mixed_case": "mixedcase"}},
+        _source=["id"],
+    )["hits"]["total"]["value"] == 0
+    assert _hit_ids(opensearch_client.search(
+        index=index,
+        query={"term": {"metadata.mixed_case": "MiXeDCase"}},
+        _source=["id"],
+    )) == ["doc-edge"]
+
+    metadata_mapping = opensearch_client.indices.get(index=index)[index]["mappings"]["properties"]["metadata"]["properties"]
+    for key in ("plain", "mixed_case", "url", "path", "command", "unicode", "long_257", "near_limit", "secondary"):
+        assert metadata_mapping[key]["type"] == "keyword"
+        assert metadata_mapping[key]["copy_to"] == ["__text__"]
+        assert "ignore_above" not in metadata_mapping[key]
+        assert "normalizer" not in metadata_mapping[key]
+        assert metadata_mapping[key].get("doc_values", True) is True
+
+    settings = opensearch_client.indices.get(index=index)[index]["settings"]["index"]
+    assert "allow_expensive_queries" not in settings.get("search", {})
+
+    too_long_doc = _sample_doc("doc-too-long", metadata={"too_long": "x" * 32767})
+    with pytest.raises(SearchBackendException) as err:
+        opensearch_client.index(index=index, id="doc-too-long", document=json.dumps(too_long_doc), refresh=True)
+
+    assert err.value.status_code == 400
+    _refresh(opensearch_client, index)
+    assert opensearch_client.exists(index=index, id="doc-too-long", _source=False) is False
 
 
 def test_opensearch_search_queries_filters_sort_source_aggregation_and_totals(opensearch_client):

--- a/test/test_datastore_opensearch.py
+++ b/test/test_datastore_opensearch.py
@@ -754,3 +754,51 @@ def test_opensearch_update_by_query_task_failure_is_visible(request):
             {"lang": "painless", "source": "ctx._source.count += "},
             {"term": {"group": "bad"}},
         )
+
+
+def test_opensearch_task_cleanup_uses_service_identity(request):
+    host = os.environ.get('AL_TEST_OPENSEARCH_HOST', 'http://127.0.0.1:9201')
+    config_data = Config().as_primitives()
+    config_data["datastore"]["type"] = "opensearch"
+    config_data["datastore"]["hosts"] = [host]
+    config_data["datastore"]["archive"]["enabled"] = False
+
+    datastore = forge.get_datastore(config=Config(config_data))
+    datastore.ds.task_wait_timeout = 30
+    collection_name = f"al_os_task_cleanup_{uuid.uuid4().hex}"
+
+    def cleanup():
+        try:
+            if datastore.ds.client:
+                datastore.ds.client.raw_client.indices.delete(index=collection_name, ignore_unavailable=True)
+        finally:
+            if not datastore.ds.is_closed():
+                datastore.ds.close()
+
+    request.addfinalizer(cleanup)
+
+    datastore.ds.register(collection_name)
+    collection = datastore.ds.__getattr__(collection_name)
+    for doc_id in ("delete-1", "delete-2", "keep-1"):
+        assert collection.save(doc_id, {"group": "delete" if doc_id.startswith("delete") else "keep"})
+    assert collection.commit()
+
+    task = datastore.ds.client.delete_by_query(
+        index=collection_name,
+        query={"term": {"group": "delete"}},
+        wait_for_completion=False,
+        conflicts="proceed",
+    )
+    task_response = datastore.ds._get_task_results(task)
+    assert task_response["deleted"] == 2
+
+    datastore.ds.client.indices.refresh(index=".tasks")
+    assert datastore.ds.client.exists(index=".tasks", id=task["task"], _source=False) is True
+
+    datastore.ds.switch_user("plumber")
+    deleted_tasks = datastore.task_cleanup()
+
+    datastore.ds.client.indices.refresh(index=".tasks")
+    assert deleted_tasks >= 1
+    assert datastore.ds.client.exists(index=".tasks", id=task["task"], _source=False) is False
+    assert collection.get("keep-1", as_obj=False)["group"] == "keep"

--- a/test/test_datastore_opensearch.py
+++ b/test/test_datastore_opensearch.py
@@ -10,6 +10,7 @@ from assemblyline.datastore.compat import SearchBackend, SearchBackendException
 from assemblyline.datastore.support.build import build_mapping
 from assemblyline.odm.models.config import Config
 from assemblyline.odm.models.alert import Alert
+from assemblyline.odm.models.file import File
 from assemblyline.odm.models.result import Section
 from assemblyline.odm.models.submission import Submission
 
@@ -589,5 +590,70 @@ def test_opensearch_full_datastore_construction_via_forge(request):
     assert collection.search("id:doc-1", rows=10, fl="id", as_obj=False, track_total_hits=True)["total"] == 0
 
     datastore.ds.client.raw_client.indices.delete(index=f"{collection_name}*", ignore_unavailable=True)
+    datastore.ds.close()
+    assert datastore.ds.is_closed()
+
+
+def test_opensearch_runtime_smoke_uses_factory_models_commit_pit_and_delete(request):
+    host = os.environ.get('AL_TEST_OPENSEARCH_HOST', 'http://127.0.0.1:9201')
+    config_data = Config().as_primitives()
+    config_data["datastore"]["type"] = "opensearch"
+    config_data["datastore"]["hosts"] = [host]
+    config_data["datastore"]["archive"]["enabled"] = False
+
+    datastore = forge.get_datastore(config=Config(config_data))
+    doc_id = "0" * 64
+
+    def cleanup():
+        try:
+            if datastore.ds.client:
+                datastore.ds.client.raw_client.indices.delete(index="file_hot", ignore_unavailable=True)
+        finally:
+            if not datastore.ds.is_closed():
+                datastore.ds.close()
+
+    request.addfinalizer(cleanup)
+
+    assert datastore.ds.backend == SearchBackend.OPENSEARCH
+    assert datastore.ds.client.info()["version"]["distribution"] == "opensearch"
+    assert datastore.ds.ping() is True
+
+    file_collection = datastore.file
+    assert datastore.submission.name == "submission"
+    assert datastore.alert.name == "alert"
+
+    document = File({
+        "ascii": "hello world.",
+        "classification": "U",
+        "entropy": 0.0,
+        "hex": "68656c6c6f20776f726c642e",
+        "magic": "ASCII text",
+        "md5": "0" * 32,
+        "sha1": "0" * 40,
+        "sha256": doc_id,
+        "size": 12,
+        "ssdeep": "3:abc:abc",
+        "type": "unknown",
+    })
+    assert file_collection.save(doc_id, document)
+    assert file_collection.commit()
+
+    fetched = file_collection.get(doc_id)
+    assert fetched.sha256 == doc_id
+    assert fetched.type == "unknown"
+
+    search = file_collection.search("sha256:" + doc_id, rows=10, fl="id,sha256,type", as_obj=False,
+                                    track_total_hits=True)
+    assert search["total"] == 1
+    assert search["items"] == [{"id": doc_id, "sha256": doc_id, "type": "unknown"}]
+
+    pit_page = file_collection.search("sha256:" + doc_id, rows=1, fl="id", as_obj=False, deep_paging_id="start")
+    assert pit_page["items"] == [{"id": doc_id}]
+
+    assert file_collection.delete(doc_id)
+    assert file_collection.commit()
+    assert file_collection.search("sha256:" + doc_id, rows=10, fl="id", as_obj=False,
+                                  track_total_hits=True)["total"] == 0
+
     datastore.ds.close()
     assert datastore.ds.is_closed()

--- a/test/test_datastore_opensearch.py
+++ b/test/test_datastore_opensearch.py
@@ -1,0 +1,430 @@
+import json
+from copy import deepcopy
+
+import pytest
+
+from assemblyline.datastore.support.build import build_mapping
+from assemblyline.odm.models.alert import Alert
+from assemblyline.odm.models.result import Section
+from assemblyline.odm.models.submission import Submission
+
+
+INDEX_SETTINGS = {
+    "index": {
+        "number_of_shards": 1,
+        "number_of_replicas": 0,
+    },
+    "analysis": {
+        "analyzer": {
+            "text_whitespace": {
+                "type": "whitespace",
+            },
+        },
+        "normalizer": {
+            "lowercase_normalizer": {
+                "type": "custom",
+                "char_filter": [],
+                "filter": ["lowercase"],
+            },
+        },
+    },
+}
+
+BASE_PROPERTIES = {
+    "id": {
+        "type": "keyword",
+        "store": True,
+        "doc_values": True,
+        "copy_to": "__text__",
+    },
+    "__text__": {
+        "type": "text",
+        "store": False,
+    },
+    "keyword_s": {
+        "type": "keyword",
+        "store": True,
+        "normalizer": "lowercase_normalizer",
+    },
+    "text_t": {
+        "type": "text",
+        "store": True,
+        "analyzer": "text_whitespace",
+    },
+    "date_dt": {
+        "type": "date",
+        "format": "date_optional_time||epoch_millis",
+        "store": True,
+    },
+    "ip_ip": {
+        "type": "ip",
+        "store": True,
+    },
+    "nested_items": {
+        "type": "nested",
+        "properties": {
+            "name": {"type": "keyword"},
+            "count": {"type": "integer"},
+        },
+    },
+    "object_data": {
+        "type": "object",
+        "properties": {
+            "flag": {"type": "keyword"},
+            "count": {"type": "integer"},
+        },
+    },
+    "wildcard_w": {
+        "type": "wildcard",
+    },
+    "count_i": {
+        "type": "integer",
+        "store": True,
+    },
+}
+
+
+def _model_mapping(*fields):
+    properties, dynamic_templates = build_mapping(fields, allow_refuse_implicit=False)
+    return {
+        "dynamic": True,
+        "properties": properties,
+        "dynamic_templates": dynamic_templates,
+    }
+
+
+def _contains_mapping_type(mapping, mapping_type):
+    if isinstance(mapping, dict):
+        if mapping.get("type") == mapping_type:
+            return True
+        return any(_contains_mapping_type(value, mapping_type) for value in mapping.values())
+    if isinstance(mapping, list):
+        return any(_contains_mapping_type(value, mapping_type) for value in mapping)
+    return False
+
+
+def _template(mapping, name):
+    return next(template[name] for template in mapping["dynamic_templates"] if name in template)
+
+
+def _test_mappings():
+    actual_model_mappings = _model_mapping(
+        Submission.fields()["metadata"],
+        Section.fields()["safelisted_tags"],
+    )
+    mappings = deepcopy(actual_model_mappings)
+    mappings["properties"].update(deepcopy(BASE_PROPERTIES))
+    return mappings
+
+
+INDEX_MAPPINGS = _test_mappings()
+
+ALERT_METADATA_MAPPINGS = _model_mapping(Alert.fields()["metadata"])
+SUBMISSION_METADATA_MAPPINGS = _model_mapping(Submission.fields()["metadata"])
+SAFELISTED_TAGS_MAPPINGS = _model_mapping(Section.fields()["safelisted_tags"])
+
+EXPECTED_METADATA_TEMPLATE = {
+    "path_match": "metadata.*",
+    "mapping": {
+        "type": "wildcard",
+        "copy_to": "__text__",
+    },
+}
+
+EXPECTED_SAFELISTED_TAGS_TEMPLATE = {
+    "path_match": "safelisted_tags.*",
+    "mapping": {
+        "type": "keyword",
+    },
+}
+
+OPENSEARCH_METADATA_TEMPLATE = {
+    "path_match": "metadata.*",
+    "mapping": {
+        "type": "keyword",
+        "copy_to": "__text__",
+    },
+}
+
+
+def _create_index(client, index, alias=None):
+    response = client.indices.create(index=index, mappings=INDEX_MAPPINGS, settings=INDEX_SETTINGS)
+    assert response["acknowledged"] is True
+    if alias:
+        assert client.indices.put_alias(index=index, name=alias)["acknowledged"] is True
+
+
+def _refresh(client, index):
+    response = client.indices.refresh(index=index)
+    assert response["_shards"]["failed"] == 0
+
+
+def _sample_doc(doc_id, **overrides):
+    doc = {
+        "id": doc_id,
+        "keyword_s": "Alpha",
+        "text_t": "hello OpenSearch",
+        "date_dt": "2026-07-03T12:00:00.000Z",
+        "ip_ip": "192.0.2.10",
+        "nested_items": [{"name": "one", "count": 1}],
+        "object_data": {"flag": "blue", "count": 7},
+        "metadata": {"campaign": "Alpha-2026", "submitter_team": "Blue Team"},
+        "safelisted_tags": {"network.static.ip": ["192.0.2.10"], "file.name": ["safe.exe"]},
+        "wildcard_w": "service/example/path",
+        "count_i": 10,
+    }
+    doc.update(overrides)
+    return doc
+
+
+def test_opensearch_connection_info_and_ping(opensearch_client):
+    info = opensearch_client.info()
+
+    assert opensearch_client.ping() is True
+    assert info["version"]["distribution"] == "opensearch"
+    assert info["version"]["number"].startswith("2.12.")
+
+
+def test_opensearch_index_mapping_alias_and_refresh(opensearch_client):
+    index = opensearch_client.make_index_name("mapping")
+    alias = opensearch_client.make_index_name("mapping_alias")
+
+    assert opensearch_client.indices.exists(index=index) is False
+    _create_index(opensearch_client, index, alias=alias)
+
+    assert opensearch_client.indices.exists(index=index) is True
+    assert opensearch_client.indices.exists_alias(name=alias) is True
+    _refresh(opensearch_client, alias)
+
+    index_data = opensearch_client.indices.get(index=index)[index]
+    properties = index_data["mappings"]["properties"]
+    settings = index_data["settings"]["index"]
+
+    assert settings["number_of_shards"] == "1"
+    assert settings["number_of_replicas"] == "0"
+    assert properties["keyword_s"]["type"] == "keyword"
+    assert properties["keyword_s"]["normalizer"] == "lowercase_normalizer"
+    assert properties["text_t"]["type"] == "text"
+    assert properties["text_t"]["analyzer"] == "text_whitespace"
+    assert properties["date_dt"]["type"] == "date"
+    assert properties["ip_ip"]["type"] == "ip"
+    assert properties["nested_items"]["type"] == "nested"
+    assert properties["object_data"].get("type", "object") == "object"
+    assert properties["wildcard_w"]["type"] == "keyword"
+    assert _template(index_data["mappings"], "metadata.*_wildcard_tpl") == OPENSEARCH_METADATA_TEMPLATE
+    assert _template(index_data["mappings"], "safelisted_tags.*_wildcard_tpl") == EXPECTED_SAFELISTED_TAGS_TEMPLATE
+
+
+def test_opensearch_supported_model_mappings_do_not_use_native_flattened():
+    # OpenSearch flat_object is not behaviorally equivalent to Elasticsearch flattened.
+    assert _template(ALERT_METADATA_MAPPINGS, "metadata.*_wildcard_tpl") == EXPECTED_METADATA_TEMPLATE
+    assert _template(SUBMISSION_METADATA_MAPPINGS, "metadata.*_wildcard_tpl") == EXPECTED_METADATA_TEMPLATE
+    assert _template(SAFELISTED_TAGS_MAPPINGS, "safelisted_tags.*_wildcard_tpl") == EXPECTED_SAFELISTED_TAGS_TEMPLATE
+    assert not _contains_mapping_type(ALERT_METADATA_MAPPINGS, "flattened")
+    assert not _contains_mapping_type(SUBMISSION_METADATA_MAPPINGS, "flattened")
+    assert not _contains_mapping_type(SAFELISTED_TAGS_MAPPINGS, "flattened")
+    assert not _contains_mapping_type(INDEX_MAPPINGS, "flattened")
+
+
+def test_opensearch_crud_and_version_fields(opensearch_client):
+    index = opensearch_client.make_index_name("crud")
+    _create_index(opensearch_client, index)
+
+    doc = _sample_doc("doc-1")
+    created = opensearch_client.index(index=index, id="doc-1", document=json.dumps(doc), op_type="create", refresh=True)
+    assert created["result"] == "created"
+    assert "_seq_no" in created
+    assert "_primary_term" in created
+
+    assert opensearch_client.exists(index=index, id="doc-1", _source=False) is True
+    fetched = opensearch_client.get(index=index, id="doc-1")
+    assert fetched["_source"]["keyword_s"] == "Alpha"
+
+    updated = opensearch_client.update(
+        index=index,
+        id="doc-1",
+        script={"lang": "painless", "source": "ctx._source.count_i += params.value", "params": {"value": 5}},
+        refresh=True,
+    )
+    assert updated["result"] == "updated"
+    assert opensearch_client.get(index=index, id="doc-1")["_source"]["count_i"] == 15
+
+    deleted = opensearch_client.delete(index=index, id="doc-1", refresh=True)
+    assert deleted["result"] == "deleted"
+    assert opensearch_client.exists(index=index, id="doc-1", _source=False) is False
+
+
+def test_opensearch_mget_bulk_and_bulk_errors(opensearch_client):
+    index = opensearch_client.make_index_name("bulk")
+    _create_index(opensearch_client, index)
+
+    operations = "\n".join([
+        json.dumps({"create": {"_index": index, "_id": "doc-1"}}),
+        json.dumps(_sample_doc("doc-1")),
+        json.dumps({"create": {"_index": index, "_id": "doc-2"}}),
+        json.dumps(_sample_doc("doc-2", keyword_s="Beta", count_i=20)),
+        json.dumps({"update": {"_index": index, "_id": "doc-2"}}),
+        json.dumps({"doc": {"count_i": 25}}),
+    ])
+    result = opensearch_client.bulk(operations=operations, refresh=True)
+    assert result["errors"] is False
+
+    docs = opensearch_client.mget(index=index, ids=["doc-1", "doc-2", "missing"])["docs"]
+    assert [doc["found"] for doc in docs] == [True, True, False]
+    assert docs[1]["_source"]["count_i"] == 25
+
+    duplicate = "\n".join([
+        json.dumps({"create": {"_index": index, "_id": "doc-1"}}),
+        json.dumps(_sample_doc("doc-1")),
+    ])
+    duplicate_result = opensearch_client.bulk(operations=duplicate, refresh=True)
+    assert duplicate_result["errors"] is True
+    assert duplicate_result["items"][0]["create"]["status"] == 409
+
+    delete_result = opensearch_client.bulk(
+        operations=json.dumps({"delete": {"_index": index, "_id": "doc-1"}}),
+        refresh=True,
+    )
+    assert delete_result["errors"] is False
+    assert opensearch_client.exists(index=index, id="doc-1", _source=False) is False
+
+
+def test_opensearch_actual_metadata_and_safelisted_tag_behavior(opensearch_client):
+    index = opensearch_client.make_index_name("metadata")
+    _create_index(opensearch_client, index)
+
+    doc = _sample_doc(
+        "doc-1",
+        metadata={
+            "campaign": "Alpha-2026",
+            "submitter_team": "Blue Team",
+            "ingest_id": "INGEST-42",
+        },
+        safelisted_tags={
+            "network.static.ip": ["192.0.2.10"],
+            "file.name": ["safe.exe"],
+        },
+    )
+    created = opensearch_client.index(index=index, id="doc-1", document=json.dumps(doc), refresh=True)
+    assert created["result"] == "created"
+
+    fetched = opensearch_client.get(index=index, id="doc-1")
+    assert fetched["_source"]["metadata"] == doc["metadata"]
+
+    exact = opensearch_client.search(
+        index=index,
+        query={"term": {"metadata.campaign": "Alpha-2026"}},
+        _source=["id", "metadata"],
+    )
+    assert [hit["_source"]["id"] for hit in exact["hits"]["hits"]] == ["doc-1"]
+
+    wildcard = opensearch_client.search(
+        index=index,
+        query={"wildcard": {"metadata.campaign": "Alpha-*"}},
+        _source=["id"],
+    )
+    assert [hit["_source"]["id"] for hit in wildcard["hits"]["hits"]] == ["doc-1"]
+
+    exists = opensearch_client.search(
+        index=index,
+        query={"exists": {"field": "metadata.submitter_team"}},
+        _source=["id"],
+    )
+    assert [hit["_source"]["id"] for hit in exists["hits"]["hits"]] == ["doc-1"]
+
+    copied_text = opensearch_client.search(
+        index=index,
+        query={"query_string": {"default_field": "__text__", "query": '"Blue Team"'}},
+        _source=["id"],
+    )
+    assert [hit["_source"]["id"] for hit in copied_text["hits"]["hits"]] == ["doc-1"]
+
+    safelisted_tag = opensearch_client.search(
+        index=index,
+        query={"term": {"safelisted_tags.network.static.ip": "192.0.2.10"}},
+        _source=["id"],
+    )
+    assert [hit["_source"]["id"] for hit in safelisted_tag["hits"]["hits"]] == ["doc-1"]
+
+    properties = opensearch_client.indices.get(index=index)[index]["mappings"]["properties"]
+    assert properties["metadata"]["properties"]["campaign"]["type"] == "keyword"
+    assert properties["metadata"]["properties"]["campaign"]["copy_to"] == ["__text__"]
+    assert properties["metadata"]["properties"]["submitter_team"]["type"] == "keyword"
+    assert properties["safelisted_tags"]["properties"]["network"]["properties"]["static"]["properties"]["ip"]["type"] == "keyword"
+
+
+def test_opensearch_search_queries_filters_sort_source_aggregation_and_totals(opensearch_client):
+    index = opensearch_client.make_index_name("search")
+    _create_index(opensearch_client, index)
+
+    operations = "\n".join([
+        json.dumps({"create": {"_index": index, "_id": "doc-1"}}),
+        json.dumps(_sample_doc("doc-1", keyword_s="Alpha", count_i=10, ip_ip="192.0.2.10")),
+        json.dumps({"create": {"_index": index, "_id": "doc-2"}}),
+        json.dumps(_sample_doc("doc-2", keyword_s="Beta", count_i=20, ip_ip="192.0.2.20")),
+        json.dumps({"create": {"_index": index, "_id": "doc-3"}}),
+        json.dumps(_sample_doc("doc-3", keyword_s="Alpha", count_i=30, ip_ip="192.0.2.30")),
+    ])
+    assert opensearch_client.bulk(operations=operations, refresh=True)["errors"] is False
+
+    response = opensearch_client.search(
+        index=index,
+        query={
+            "bool": {
+                "must": {"query_string": {"query": "text_t:OpenSearch"}},
+                "filter": [{"range": {"count_i": {"gte": 10}}}],
+            }
+        },
+        sort=[{"count_i": "desc"}],
+        _source=["id", "keyword_s", "count_i"],
+        aggregations={"keywords": {"terms": {"field": "keyword_s"}}},
+        track_total_hits=True,
+        size=2,
+    )
+
+    assert response["hits"]["total"]["value"] == 3
+    assert [hit["_source"]["id"] for hit in response["hits"]["hits"]] == ["doc-3", "doc-2"]
+    assert set(response["hits"]["hits"][0]["_source"].keys()) == {"id", "keyword_s", "count_i"}
+    assert response["aggregations"]["keywords"]["buckets"][0]["doc_count"] == 2
+
+
+def test_opensearch_point_in_time_search_after_and_close(opensearch_client):
+    index = opensearch_client.make_index_name("pit")
+    _create_index(opensearch_client, index)
+
+    operations = "\n".join([
+        json.dumps({"create": {"_index": index, "_id": "doc-1"}}),
+        json.dumps(_sample_doc("doc-1", count_i=1)),
+        json.dumps({"create": {"_index": index, "_id": "doc-2"}}),
+        json.dumps(_sample_doc("doc-2", count_i=2)),
+        json.dumps({"create": {"_index": index, "_id": "doc-3"}}),
+        json.dumps(_sample_doc("doc-3", count_i=3)),
+    ])
+    assert opensearch_client.bulk(operations=operations, refresh=True)["errors"] is False
+
+    pit = opensearch_client.open_point_in_time(index=index, keep_alive="1m")
+    assert set(pit) == {"id"}
+
+    try:
+        first_page = opensearch_client.search(
+            pit={"id": pit["id"], "keep_alive": "1m"},
+            query={"match_all": {}},
+            sort=[{"count_i": "asc"}, {"_shard_doc": "desc"}],
+            _source=["id", "count_i"],
+            size=2,
+        )
+        assert [hit["_source"]["id"] for hit in first_page["hits"]["hits"]] == ["doc-1", "doc-2"]
+        assert "pit_id" in first_page
+
+        second_page = opensearch_client.search(
+            pit={"id": first_page["pit_id"], "keep_alive": "1m"},
+            query={"match_all": {}},
+            search_after=first_page["hits"]["hits"][-1]["sort"],
+            sort=[{"count_i": "asc"}, {"_shard_doc": "desc"}],
+            _source=["id", "count_i"],
+            size=2,
+        )
+        assert [hit["_source"]["id"] for hit in second_page["hits"]["hits"]] == ["doc-3"]
+    finally:
+        response = opensearch_client.close_point_in_time(id=pit["id"])
+        assert response["pits"][0]["successful"] is True

--- a/test/test_datastore_opensearch.py
+++ b/test/test_datastore_opensearch.py
@@ -1,10 +1,14 @@
 import json
+import os
+import uuid
 from copy import deepcopy
 
 import pytest
 
-from assemblyline.datastore.compat import SearchBackendException
+from assemblyline.common import forge
+from assemblyline.datastore.compat import SearchBackend, SearchBackendException
 from assemblyline.datastore.support.build import build_mapping
+from assemblyline.odm.models.config import Config
 from assemblyline.odm.models.alert import Alert
 from assemblyline.odm.models.result import Section
 from assemblyline.odm.models.submission import Submission
@@ -542,3 +546,48 @@ def test_opensearch_point_in_time_search_after_and_close(opensearch_client):
     finally:
         response = opensearch_client.close_point_in_time(id=pit["id"])
         assert response["pits"][0]["successful"] is True
+
+
+def test_opensearch_full_datastore_construction_via_forge(request):
+    host = os.environ.get('AL_TEST_OPENSEARCH_HOST', 'http://127.0.0.1:9201')
+    collection_name = f"al_os_forge_{uuid.uuid4().hex}"
+    config_data = Config().as_primitives()
+    config_data["datastore"]["type"] = "opensearch"
+    config_data["datastore"]["hosts"] = [host]
+    config_data["datastore"]["archive"]["enabled"] = False
+
+    datastore = forge.get_datastore(config=Config(config_data))
+
+    def cleanup():
+        try:
+            if datastore.ds.client:
+                datastore.ds.client.raw_client.indices.delete(index=f"{collection_name}*", ignore_unavailable=True)
+        finally:
+            if not datastore.ds.is_closed():
+                datastore.ds.close()
+
+    request.addfinalizer(cleanup)
+
+    assert datastore.ds.backend == SearchBackend.OPENSEARCH
+    assert datastore.ds.client.info()["version"]["distribution"] == "opensearch"
+    assert datastore.ds.ping() is True
+
+    datastore.ds.register(collection_name)
+    collection = datastore.ds.__getattr__(collection_name)
+    assert collection.save("doc-1", {"keyword_s": "Alpha", "text_t": "hello OpenSearch"}, refresh=True)
+    assert collection.get("doc-1", as_obj=False)["keyword_s"] == "Alpha"
+
+    search = collection.search("keyword_s:Alpha", rows=10, fl="id,keyword_s", as_obj=False, track_total_hits=True)
+    assert search["total"] == 1
+    assert search["items"] == [{"id": "doc-1", "keyword_s": "Alpha"}]
+
+    pit_page = collection.search("id:*", rows=1, fl="id", as_obj=False, deep_paging_id="start")
+    assert pit_page["items"] == [{"id": "doc-1"}]
+
+    assert collection.delete("doc-1")
+    datastore.ds.client.indices.refresh(index=collection_name)
+    assert collection.search("id:doc-1", rows=10, fl="id", as_obj=False, track_total_hits=True)["total"] == 0
+
+    datastore.ds.client.raw_client.indices.delete(index=f"{collection_name}*", ignore_unavailable=True)
+    datastore.ds.close()
+    assert datastore.ds.is_closed()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -73,6 +73,13 @@ def test_datastore_opensearch_type_validates():
     assert datastore.type == "opensearch"
 
 
+def test_datastore_auto_type_validates_and_serializes():
+    datastore = Datastore({**DEFAULT_DATASTORE, "type": "auto"})
+
+    assert datastore.type == "auto"
+    assert datastore.as_primitives()["type"] == "auto"
+
+
 def test_datastore_invalid_type_is_rejected():
     datastore_config = {**DEFAULT_DATASTORE, "type": "solr"}
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -4,7 +4,7 @@ from assemblyline.common import forge
 from assemblyline.odm.models.alert import Alert
 from assemblyline.odm.models.badlist import Badlist
 from assemblyline.odm.models.cached_file import CachedFile
-from assemblyline.odm.models.config import DEFAULT_CONFIG, Config
+from assemblyline.odm.models.config import DEFAULT_CONFIG, DEFAULT_DATASTORE, Config, Datastore
 from assemblyline.odm.models.emptyresult import EmptyResult
 from assemblyline.odm.models.error import Error
 from assemblyline.odm.models.file import File
@@ -57,6 +57,36 @@ def test_config_model():
 def test_default_config_model():
     config = forge.get_config(yml_config="/etc/assemblyline/default.yml")
     assert config.as_primitives() == Config(DEFAULT_CONFIG).as_primitives()
+
+
+def test_datastore_elasticsearch_type_validates():
+    datastore = Datastore(DEFAULT_DATASTORE)
+
+    assert datastore.type == "elasticsearch"
+
+
+def test_datastore_opensearch_type_validates():
+    datastore_config = {**DEFAULT_DATASTORE, "type": "opensearch"}
+
+    datastore = Datastore(datastore_config)
+
+    assert datastore.type == "opensearch"
+
+
+def test_datastore_invalid_type_is_rejected():
+    datastore_config = {**DEFAULT_DATASTORE, "type": "solr"}
+
+    with pytest.raises(ValueError, match="not in the possible values"):
+        Datastore(datastore_config)
+
+
+def test_datastore_omitted_type_defaults_to_elasticsearch():
+    datastore_config = DEFAULT_DATASTORE.copy()
+    datastore_config.pop("type")
+
+    datastore = Datastore(datastore_config)
+
+    assert datastore.type == "elasticsearch"
 
 
 def test_emptyresult_model():


### PR DESCRIPTION
## Summary

Adds OpenSearch support while keeping Elasticsearch as the default.

## What changed

* Added a compatibility layer for Elasticsearch and OpenSearch.
* Added support for search, bulk operations, mappings, aliases, PIT pagination, and async tasks.
* Added datastore selection through `datastore.type`.
* Added OpenSearch unit and integration tests.
* Added `opensearch-py`.

Replaces 2176
