### PR TITLE
Highlighter/Fix (master)

### DIFF
--- a/assemblyline/datastore/helper.py
+++ b/assemblyline/datastore/helper.py
@@ -964,10 +964,10 @@ class AssemblylineDatastore(object):
                     except Exception:
                         log.warning(f"Unable to load screenshots during submission summary. ({section['body']})")
 
-            for htype in out['heuristics']:
-                for heur in out['heuristics'][htype]:
-                    cache_key = f"{heur['heur_id']}_{key}"
-                    heur['signatures'].extend(signatures.get(cache_key, []))
+        for htype in out['heuristics']:
+            for heur in out['heuristics'][htype]:
+                cache_key = f"{heur['heur_id']}_{heur['key']}"
+                heur['signatures'] = list(set(signatures.get(cache_key, [])))
 
         return out
 


### PR DESCRIPTION
- **Problem:** 
  1. The loop populating `heur['signatures']` is nested **inside** the `for key, item in items.items():` loop.
  2. It constructs `cache_key` using the outer loop's current `key` rather than the heuristic's own `heur['key']`.
- **Impact:**
  - For each result key processed, every previously encountered heuristic has its signatures extended again.
  - If multiple results share the same heuristic ID, signatures from result BBB get attached to the heuristic record for result AAA.
  - In `submission.py:688-696`, `output['map']` iterates over `item['signatures']` and maps `heuristic.signature__{sig}` to `item['key'][:64]`. Because signatures from other files are mistakenly attached to `item`, signatures are mapped to the wrong SHA256 hashes in `output['map']`.